### PR TITLE
Add stub for VaultDatabaseConnection class and tests

### DIFF
--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -153,6 +153,69 @@ class VaultClient:
             ) from e
 
 
+class VaultDatabaseConnection:
+    """
+    Handles interactions with the Vault Database Secrets Engine.
+    """
+    def __init__(self, client):
+        """
+        Initializes the Database connection client.
+
+        Args:
+            client (VaultClient): An authenticated instance of the main VaultClient.
+        """
+        self._client = client
+        self._mount_path = "database"
+
+    def list_connections(self):
+        """
+        List all available connections.
+        """
+        path = f"v1/{self._mount_path}/config"
+        pass
+
+    def read_connection(self, name: str):
+        """
+        Read the configuration settings of a database connection.
+
+        Args:
+            name (str): The name of the connection to read.
+        """
+        path = f"v1/{self._mount_path}/config/{name}"
+        pass
+
+    def create_or_update_connection(self, name: str):
+        """
+        Create a new database connection or update an existing one.
+
+        Args:
+            name (str): The name of the connection to create or update.
+        """
+        path = f"v1/{self._mount_path}/config/{name}"
+        pass
+
+    def delete_connection(self, name: str):
+        """
+        Delete a database connection.
+
+        Args:
+            name (str): The name of the connection to delete.
+        """
+        path = f"v1/{self._mount_path}/config/{name}"
+        pass
+
+    def reset_connection(self, name: str):
+        """
+        Reset a database connection by closing the connection and its underlying plugin,
+        then restarting it.
+
+        Args:
+            name (str): The name of the connection to reset.
+        """
+        path = f"v1/{self._mount_path}/reset/{name}"
+        pass
+
+
 class VaultKv2Secrets:
     """
     Handles interactions with the KV version 2 secrets engine.

--- a/tests/unit/plugins/module_utils/test_vault_database_connection.py
+++ b/tests/unit/plugins/module_utils/test_vault_database_connection.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2025 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+    VaultClient,
+    VaultDatabaseConnection,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultPermissionError,
+)
+
+
+@pytest.fixture
+def vault_config():
+    return {
+        "addr": "http://mock-vault:8200",
+        "token": "mock-token",
+        "namespace": "root",
+        "database_name": "test-database",
+    }
+
+
+@pytest.fixture
+def authenticated_client(mocker, vault_config):
+    client = VaultClient(
+        vault_address=vault_config["addr"], vault_namespace=vault_config["namespace"]
+    )
+    client.set_token(vault_config["token"])
+    client._make_request = MagicMock()
+    return client
+
+
+def test_list_connections_success(authenticated_client, vault_config):
+    pass
+
+
+def test_list_connections_error(authenticated_client, vault_config):
+    pass
+
+
+def test_read_connection_success(authenticated_client, vault_config):
+    pass
+
+
+def test_read_connection_error(authenticated_client, vault_config):
+    pass
+
+
+def test_create_or_update_connection_success(authenticated_client, vault_config):
+    pass
+
+
+def test_create_or_update_connection_error(authenticated_client, vault_config):
+    pass
+
+
+def test_delete_connection_success(authenticated_client, vault_config):
+    pass
+
+
+def test_delete_connection_error(authenticated_client, vault_config):
+    pass
+
+
+def test_reset_connection_success(authenticated_client, vault_config):
+    pass
+
+
+def test_reset_connection_error(authenticated_client, vault_config):
+    pass


### PR DESCRIPTION
Related to [ACA-5049](https://issues.redhat.com/browse/ACA-5049) 
This PR adds a stub implementation for the `VaultDatabaseConnection` class to support HashiCorp Vault's Database Secrets Engine connection management in order to make collaboration on the implementation easier. The actual implementation will be added in future prs. 
