### PR TITLE
Fix Pinned Hash Check: changed gh actions refs to pinned commit hashes

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,10 +20,10 @@ jobs:
         python-version:
           - "3.12"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -16,10 +16,10 @@ jobs:
       # contents:read is required to checkout the repository source code
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Install python 3.11
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: 3.11
 


### PR DESCRIPTION
Pinning GitHub Actions to a full-length commit SHA (hash) is a critical supply chain security best practice because it guarantees immutability, ensuring that the exact, audited code version is executed every time the workflow runs.

The following versions were pinned:

- actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
- actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0