### PR TITLE
Run black on tests/ and plugins/

### DIFF
--- a/plugins/doc_fragments/__init__.py
+++ b/plugins/doc_fragments/__init__.py
@@ -5,5 +5,4 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type

--- a/plugins/doc_fragments/vault_auth.py
+++ b/plugins/doc_fragments/vault_auth.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -5,11 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 from ansible.module_utils.basic import env_fallback
-
 
 # Authentication parameters
 AUTH_ARG_SPEC = {

--- a/plugins/module_utils/authentication.py
+++ b/plugins/module_utils/authentication.py
@@ -132,7 +132,7 @@ class AppRoleAuthenticator(Authenticator):
             headers["X-Vault-Namespace"] = vault_namespace
 
         try:
-            response = requests.post(login_url, json=payload, headers=headers)
+            response = requests.post(login_url, json=payload, headers=headers, timeout=30)
 
             response.raise_for_status()
 

--- a/plugins/module_utils/authentication.py
+++ b/plugins/module_utils/authentication.py
@@ -5,11 +5,9 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 from abc import ABC, abstractmethod
-
 
 try:
     import requests

--- a/plugins/module_utils/authentication.py
+++ b/plugins/module_utils/authentication.py
@@ -132,7 +132,7 @@ class AppRoleAuthenticator(Authenticator):
             headers["X-Vault-Namespace"] = vault_namespace
 
         try:
-            response = requests.post(login_url, json=payload, headers=headers, timeout=30)
+            response = requests.post(login_url, json=payload, headers=headers, timeout=90)
 
             response.raise_for_status()
 

--- a/plugins/module_utils/vault_auth_utils.py
+++ b/plugins/module_utils/vault_auth_utils.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 """

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -5,14 +5,12 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 import json  # noqa: F401
 import logging
 
 from typing import Any, Dict, List, Optional
-
 
 try:
     import requests
@@ -28,7 +26,6 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
     VaultPermissionError,
     VaultSecretNotFoundError,
 )
-
 
 logger = logging.getLogger(__name__)
 
@@ -157,6 +154,7 @@ class VaultDatabaseConnection:
     """
     Handles interactions with the Vault Database Secrets Engine.
     """
+
     def __init__(self, client):
         """
         Initializes the Database connection client.

--- a/plugins/module_utils/vault_exceptions.py
+++ b/plugins/module_utils/vault_exceptions.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 

--- a/plugins/modules/kv1_secret.py
+++ b/plugins/modules/kv1_secret.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 DOCUMENTATION = """

--- a/plugins/modules/kv1_secret_info.py
+++ b/plugins/modules/kv1_secret_info.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 DOCUMENTATION = """

--- a/plugins/modules/kv2_secret.py
+++ b/plugins/modules/kv2_secret.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -121,7 +120,6 @@ import copy
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
-
 
 try:
     from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (

--- a/plugins/modules/kv2_secret_info.py
+++ b/plugins/modules/kv2_secret_info.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 DOCUMENTATION = """
@@ -65,7 +64,6 @@ import copy
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
-
 
 try:
     from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (

--- a/tests/unit/plugins/module_utils/test_authentication.py
+++ b/tests/unit/plugins/module_utils/test_authentication.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 from unittest.mock import Mock, patch

--- a/tests/unit/plugins/module_utils/test_vault_client.py
+++ b/tests/unit/plugins/module_utils/test_vault_client.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 from unittest.mock import MagicMock, Mock, patch
@@ -25,7 +24,6 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
     VaultPermissionError,
     VaultSecretNotFoundError,
 )
-
 
 MOCK_REQUESTS_SESSION = (
     "ansible_collections.hashicorp.vault.plugins.module_utils.vault_client.requests.Session"

--- a/tests/unit/plugins/module_utils/test_vault_database_connection.py
+++ b/tests/unit/plugins/module_utils/test_vault_database_connection.py
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 from unittest.mock import MagicMock

--- a/tests/unit/plugins/module_utils/test_vault_kv1_client.py
+++ b/tests/unit/plugins/module_utils/test_vault_kv1_client.py
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 import random

--- a/tests/unit/plugins/module_utils/test_vault_kv2_client.py
+++ b/tests/unit/plugins/module_utils/test_vault_kv2_client.py
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 from __future__ import absolute_import, division, print_function
 
-
 __metaclass__ = type
 
 from unittest.mock import MagicMock


### PR DESCRIPTION
**Summary:**
[ACA-5173](https://issues.redhat.com/browse/ACA-5173)
This fixes the CI errors as seen [here](https://github.com/hashicorp/hashicorp.vault/actions/runs/22859848942/job/66310391723?pr=31)

This also fixes the lint error `ERROR: plugins/module_utils/authentication.py:135:23: missing-timeout: Missing timeout argument for method 'requests.post' can cause your program to hang indefinitely` 

**Not included in this pr:**
The other linting CI failures:

```
tests/unit/plugins/module_utils/test_vault_database_connection.py:13:1: F401
'ansible_collections.hashicorp.vault.plugins.module_utils.vault_client.VaultDatabaseConnection' imported but unused
tests/unit/plugins/module_utils/test_vault_database_connection.py:17:1: F401
 'ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions.VaultPermissionError' imported but unused
```
are caused by the class stub added in https://github.com/hashicorp/hashicorp.vault/pull/31 and will be fixed once the class is fully implemented. 