### PR TITLE
ACA-5146: modified all instances of previous repo url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,8 +15,8 @@ This release includes new modules and lookup plugin for KV1 secret management.
 Minor Changes
 -------------
 
-- Add an action group for the collection modules ``kv1_secret``, ``kv1_secret_info``, ``kv2_secret``, ``kv2_secret_info`` (https://github.com/ansible-automation-platform/hashicorp.vault/pull/23).
-- kv2_secret_info - module will not fail when the requested secret does not exist instead returns an empty response (https://github.com/ansible-automation-platform/hashicorp.vault/pull/23).
+- Add an action group for the collection modules ``kv1_secret``, ``kv1_secret_info``, ``kv2_secret``, ``kv2_secret_info`` (https://github.com/ansible-collections/hashicorp.vault/pull/23).
+- kv2_secret_info - module will not fail when the requested secret does not exist instead returns an empty response (https://github.com/ansible-collections/hashicorp.vault/pull/23).
 
 New Plugins
 -----------

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ Tested with the Python >= 3.10 versions.
 ### Lookup plugins
 Name | Description
 --- | ---
-[hashicorp.vault.kv2_secret_get](https://github.com/ansible-automation-platform/hashicorp.vault/blob/main/plugins/lookup/kv2_secret_get.py)|Look up KV2 secrets stored in Hasicorp vault
+[hashicorp.vault.kv2_secret_get](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/lookup/kv2_secret_get.py)|Look up KV2 secrets stored in Hasicorp vault
 
 <!--end collection content-->
 
 ### Modules
 Name | Description
 --- | ---
-[hashicorp.vault.kv2_secret](https://github.com/ansible-automation-platform/hashicorp.vault/blob/main/plugins/modules/kv2_secret.py)|Manage HashiCorp Vault KV version 2 secrets
-[hashicorp.vault.kv2_secret_info](https://github.com/ansible-automation-platform/hashicorp.vault/blob/main/plugins/modules/kv2_secret_info.py)|Read HashiCorp Vault KV version 2 secrets
+[hashicorp.vault.kv2_secret](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret.py)|Manage HashiCorp Vault KV version 2 secrets
+[hashicorp.vault.kv2_secret_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret_info.py)|Read HashiCorp Vault KV version 2 secrets
 
 ## Installation
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -22,9 +22,9 @@ releases:
     changes:
       minor_changes:
       - Add an action group for the collection modules ``kv1_secret``, ``kv1_secret_info``,
-        ``kv2_secret``, ``kv2_secret_info`` (https://github.com/ansible-automation-platform/hashicorp.vault/pull/23).
+        ``kv2_secret``, ``kv2_secret_info`` (https://github.com/ansible-collections/hashicorp.vault/pull/23).
       - kv2_secret_info - module will not fail when the requested secret does not
-        exist instead returns an empty response (https://github.com/ansible-automation-platform/hashicorp.vault/pull/23).
+        exist instead returns an empty response (https://github.com/ansible-collections/hashicorp.vault/pull/23).
       release_summary: This release includes new modules and lookup plugin for KV1
         secret management.
     fragments:

--- a/changelogs/fragments/20251007-add-action-group.yaml
+++ b/changelogs/fragments/20251007-add-action-group.yaml
@@ -1,6 +1,6 @@
 ---
 minor_changes:
   - Add an action group for the collection modules ``kv1_secret``, ``kv1_secret_info``, ``kv2_secret``, ``kv2_secret_info``
-    (https://github.com/ansible-automation-platform/hashicorp.vault/pull/23).
+    (https://github.com/ansible-collections/hashicorp.vault/pull/23).
   - kv2_secret_info - module will not fail when the requested secret does not exists instead returns an empty response
-    (https://github.com/ansible-automation-platform/hashicorp.vault/pull/23).
+    (https://github.com/ansible-collections/hashicorp.vault/pull/23).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -19,7 +19,7 @@ tags: ["hashicorp", "vault", "security", "infrastructure"]
 dependencies:
   "ansible.utils": "*" # note: "*" selects the latest version available
 
-repository: https://github.com/ansible
+repository: https://github.com/ansible-collections/hashicorp.vault
 homepage: http://ansible.com/
 issues: https://access.redhat.com/support/
 


### PR DESCRIPTION
##### SUMMARY                     

  Update GitHub organization paths across the codebase to reflect the correct repository location at                                              
  `github.com/ansible-collections/hashicorp.vault`. This change updates all references from the old paths
  (`github.com/ansible-automation-platform/` and incomplete `github.com/ansible/`) to the correct `ansible-collections` organization.             
                  
  This ensures:
  - Users can find the correct repository location
  - Links to modules, plugins, and changelog work correctly
  - The galaxy.yml repository metadata points to the correct location

  ##### ISSUE TYPE
  - Docs Pull Request

  ##### COMPONENT NAME
  - galaxy.yml
  - README.md
  - CHANGELOG.rst
  - changelogs/

  ##### ADDITIONAL INFORMATION

  Files updated:
  - `galaxy.yml`: Updated repository URL to the complete ansible-collections path
  - `README.md`: Updated 3 module/plugin documentation links
  - `CHANGELOG.rst`: Updated 2 PR reference links
  - `changelogs/changelog.yaml`: Updated 2 PR reference links
  - `changelogs/fragments/20251007-add-action-group.yaml`: Updated 2 PR reference links