### PR TITLE
[Manual Backport][Stable-1] ACA-5050: vault_client module_utils configure(), delete(), reset() (#36)

### DIFF
--- a/changelogs/fragments/36-database-connection-methods.yaml
+++ b/changelogs/fragments/36-database-connection-methods.yaml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - module_utils/vault_client.py - Implement create_or_update_connection() in VaultDatabaseConnection class
+    (https://github.com/ansible-automation-platform/hashicorp.vault/pull/36).
+  - module_utils/vault_client.py - Implement delete_connection() in VaultDatabaseConnection class
+    (https://github.com/ansible-automation-platform/hashicorp.vault/pull/36).
+  - module_utils/vault_client.py - Implement reset_connection() in VaultDatabaseConnection class
+    (https://github.com/ansible-automation-platform/hashicorp.vault/pull/36).

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -159,7 +159,7 @@ class VaultDatabaseConnection:
             mount_path (str): The mount path of the database secrets engine. Defaults to "database".
         """
         self._client = client
-        self._mount_path = mount_path
+        self._mount_path = (mount_path or "database").strip().strip("/")
 
     def list_connections(self) -> list:
         """
@@ -190,36 +190,79 @@ class VaultDatabaseConnection:
 
         return response_data.get("data", {})
 
-    def create_or_update_connection(self, name: str):
+    def create_or_update_connection(self, name: str, config: dict) -> dict:
         """
-        Create a new database connection or update an existing one.
+        Configure a database connection.
 
         Args:
-            name (str): The name of the connection to create or update.
-        """
-        path = f"v1/{self._mount_path}/config/{name}"
-        pass
+            name (str): The name of the database connection
+            config (dict): Connection configuration containing:
+                - plugin_name (str, required): Database plugin type (e.g., 'postgresql-database-plugin')
+                - plugin_version (str, optional): Semantic version of the plugin
+                - allowed_roles (list, optional): Roles allowed to use this connection
+                - verify_connection (bool, optional): Verify during setup (default: true)
+                - root_rotation_statements (list, optional): Statements to execute during root rotation
+                - password_policy (str, optional): Password policy to use for the connection
+                - Other common fields (reference the individual plugin documentation to determine support)
+                  - connection_url (str, optional): Database connection string
+                  - username (str, optional): Database username
+                  - password (str, optional): Database password
+                  - disable_escaping (bool, optional): Disable escaping of special characters in the connection URL (default: false)
 
-    def delete_connection(self, name: str):
+        Returns:
+            dict: Response from Vault
+
+        Raises:
+            TypeError: If config is not a dict, or if config does not contain
+                "plugin_name" with a string value.
+
+        Example:
+            db.create_or_update_connection(
+              name="my-postgres-db",
+              config={
+                  "plugin_name": "postgresql-database-plugin",
+                  "connection_url": "postgresql://{{username}}:{{password}}@localhost:5432/mydb",
+                  "username": "vault",
+                  "password": "secret",
+                  "allowed_roles": ["readonly", "readwrite"]}
+              )
+        """
+        if not isinstance(config, dict):
+            raise TypeError("config must be a dict")
+        if "plugin_name" not in config:
+            raise TypeError('config must contain "plugin_name"')
+        if not isinstance(config["plugin_name"], str):
+            raise TypeError('config["plugin_name"] must be a str')
+
+        path = f"v1/{self._mount_path}/config/{name}"
+        return self._client._make_request("POST", path, json=config)
+
+    def delete_connection(self, name: str) -> None:
         """
         Delete a database connection.
 
         Args:
             name (str): The name of the connection to delete.
+
+        Returns:
+            None
         """
         path = f"v1/{self._mount_path}/config/{name}"
-        pass
+        self._client._make_request("DELETE", path)
 
-    def reset_connection(self, name: str):
+    def reset_connection(self, name: str) -> None:
         """
         Reset a database connection by closing the connection and its underlying plugin,
         then restarting it.
 
         Args:
             name (str): The name of the connection to reset.
+
+        Returns:
+            None
         """
         path = f"v1/{self._mount_path}/reset/{name}"
-        pass
+        self._client._make_request("POST", path, json={})
 
 
 class VaultKv2Secrets:

--- a/tests/unit/plugins/module_utils/test_vault_database_connection.py
+++ b/tests/unit/plugins/module_utils/test_vault_database_connection.py
@@ -15,6 +15,7 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client impor
     VaultDatabaseConnection,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
     VaultPermissionError,
     VaultSecretNotFoundError,
 )
@@ -22,6 +23,7 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
 
 @pytest.fixture
 def vault_config():
+    """Vault configuration for testing."""
     return {
         "addr": "http://mock-vault:8200",
         "token": "mock-token",
@@ -61,10 +63,36 @@ def mock_read_connection_response():
 
 @pytest.fixture
 def authenticated_client(mocker, vault_config):
+    """Authenticated Vault client for testing."""
     client = VaultClient(vault_address=vault_config["addr"], vault_namespace=vault_config["namespace"])
     client.set_token(vault_config["token"])
     client._make_request = MagicMock()
     return client
+
+
+@pytest.fixture
+def mock_configure_response():
+    """Mock response from Vault for configure/update operations."""
+    return {
+        "request_id": "1234567890",
+        "lease_id": "",
+        "lease_duration": 0,
+        "renewable": False,
+        "data": None,
+        "warnings": None,
+    }
+
+
+@pytest.fixture
+def sample_db_config():
+    """Sample database configuration for testing."""
+    return {
+        "plugin_name": "mysql-database-plugin",
+        "allowed_roles": "readonly",
+        "connection_url": "{{username}}:{{password}}@tcp(127.0.0.1:3306)/",
+        "username": "vaultuser",
+        "password": "secretpassword",
+    }
 
 
 class TestDatabaseListConnections:
@@ -137,25 +165,124 @@ class TestDatabaseReadConnection:
             db_conn.read_connection(vault_config["database_name"])
 
 
-def test_create_or_update_connection_success(authenticated_client, vault_config):
-    pass
+class TestCreateOrUpdateConnection:
+    """Test suite for create_or_update_connection."""
+
+    def test_create_or_update_connection_success(
+        self, authenticated_client, vault_config, sample_db_config, mock_configure_response
+    ):
+        """Test that create_or_update_connection creates a new connection if it doesn't exist."""
+        authenticated_client._make_request.return_value = mock_configure_response
+
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        result = db_conn.create_or_update_connection(vault_config["database_name"], sample_db_config)
+        expected_path = f"v1/database/config/{vault_config['database_name']}"
+        authenticated_client._make_request.assert_called_once_with("POST", expected_path, json=sample_db_config)
+
+        assert result == mock_configure_response
+
+    def test_create_or_update_connection_error(self, authenticated_client, vault_config, sample_db_config):
+        """Test that create_or_update_connection raises VaultApiError if the API request fails."""
+        authenticated_client._make_request.side_effect = VaultApiError("Test error")
+
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        with pytest.raises(VaultApiError):
+            db_conn.create_or_update_connection(vault_config["database_name"], sample_db_config)
+
+    def test_create_or_update_connection_invalid_config(self, authenticated_client, vault_config):
+        """Test that create_or_update_connection raises TypeError if config is not a dict."""
+        db_conn = VaultDatabaseConnection(authenticated_client)
+
+        with pytest.raises(TypeError, match="config must be a dict"):
+            db_conn.create_or_update_connection(vault_config["database_name"], "invalid_config")
+        authenticated_client._make_request.assert_not_called()
+
+    def test_create_or_update_connection_missing_plugin_name(self, authenticated_client, vault_config):
+        """Test that create_or_update_connection raises TypeError if config lacks plugin_name."""
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        config_without_plugin = {
+            "connection_url": "postgresql://localhost:5432/mydb",
+            "username": "vault",
+        }
+
+        with pytest.raises(TypeError, match='config must contain "plugin_name"'):
+            db_conn.create_or_update_connection(vault_config["database_name"], config_without_plugin)
+        authenticated_client._make_request.assert_not_called()
+
+    def test_create_or_update_connection_plugin_name_not_string(self, authenticated_client, vault_config):
+        """Test that create_or_update_connection raises TypeError if plugin_name is not a str."""
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        config_plugin_name_not_str = {
+            "plugin_name": 123,
+            "connection_url": "postgresql://localhost:5432/mydb",
+        }
+
+        with pytest.raises(TypeError, match='config\\["plugin_name"\\] must be a str'):
+            db_conn.create_or_update_connection(vault_config["database_name"], config_plugin_name_not_str)
+        authenticated_client._make_request.assert_not_called()
+
+    def test_create_or_update_connection_with_minimal_config(
+        self, authenticated_client, vault_config, mock_configure_response
+    ):
+        """Test configuration with minimal required parameters."""
+        authenticated_client._make_request.return_value = mock_configure_response
+
+        minimal_config = {
+            "plugin_name": "mysql-database-plugin",
+            "connection_url": "{{username}}:{{password}}@tcp(127.0.0.1:3306)/",
+        }
+
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        result = db_conn.create_or_update_connection(vault_config["database_name"], minimal_config)
+
+        expected_path = f"v1/database/config/{vault_config['database_name']}"
+        authenticated_client._make_request.assert_called_once_with("POST", expected_path, json=minimal_config)
+        assert result == mock_configure_response
 
 
-def test_create_or_update_connection_error(authenticated_client, vault_config):
-    pass
+class TestDeleteConnection:
+    """Test suite for delete_connection."""
+
+    def test_delete_connection_success(self, authenticated_client, vault_config, mock_configure_response):
+        """Test that delete_connection deletes a connection if it exists."""
+        authenticated_client._make_request.return_value = mock_configure_response
+
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        result = db_conn.delete_connection(vault_config["database_name"])
+
+        expected_path = f"v1/database/config/{vault_config['database_name']}"
+        authenticated_client._make_request.assert_called_once_with("DELETE", expected_path)
+
+        assert result is None
+
+    def test_delete_connection_error(self, authenticated_client, vault_config):
+        """Test that delete_connection raises VaultApiError if the API request fails."""
+        authenticated_client._make_request.side_effect = VaultApiError("Test error")
+
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        with pytest.raises(VaultApiError):
+            db_conn.delete_connection(vault_config["database_name"])
 
 
-def test_delete_connection_success(authenticated_client, vault_config):
-    pass
+class TestResetConnection:
+    """Test suite for reset_connection."""
 
+    def test_reset_connection_success(self, authenticated_client, vault_config, mock_configure_response):
+        """Test that reset_connection resets a connection if it exists."""
+        authenticated_client._make_request.return_value = mock_configure_response
 
-def test_delete_connection_error(authenticated_client, vault_config):
-    pass
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        result = db_conn.reset_connection(vault_config["database_name"])
 
+        expected_path = f"v1/database/reset/{vault_config['database_name']}"
+        authenticated_client._make_request.assert_called_once_with("POST", expected_path, json={})
 
-def test_reset_connection_success(authenticated_client, vault_config):
-    pass
+        assert result is None
 
+    def test_reset_connection_error(self, authenticated_client, vault_config):
+        """Test that reset_connection raises VaultApiError if the API request fails."""
+        authenticated_client._make_request.side_effect = VaultApiError("Test error")
 
-def test_reset_connection_error(authenticated_client, vault_config):
-    pass
+        db_conn = VaultDatabaseConnection(authenticated_client)
+        with pytest.raises(VaultApiError):
+            db_conn.reset_connection(vault_config["database_name"])


### PR DESCRIPTION
Cherry-pick backport of PR #36 from main to stable-1.

Original commit: 9e0c42d