### PR TITLE
ACA-2437: Add CI.md documentation file

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -1,6 +1,6 @@
 # Continuous Integration (CI)
 
-## HashiCorp Vault Upstream Testing
+## HashiCorp Vault Collection Testing
 
 GitHub Actions are used to run the CI for the hashicorp.vault collection. The workflows used for the CI can be found in the [.github/workflows](.github/workflows) directory.
 
@@ -8,20 +8,49 @@ GitHub Actions are used to run the CI for the hashicorp.vault collection. The wo
 
 The following tests run on every pull request:
 
-| Job | Description | Python Versions | ansible-core Versions |
-| --- | ----------- | --------------- | --------------------- |
-| [Changelog](.github/workflows/changelog.yml) | Checks for the presence of changelog fragments | 3.12 | devel |
-| [Linters](.github/workflows/linters.yml) | Runs `black`, `flake8`, and `isort` on plugins and tests | 3.11 | N/A |
-| [Sanity](.github/workflows/sanity.yml) | Runs ansible sanity checks | See compatibility table below | 2.16 |
-| [Unit tests](.github/workflows/units.yml) | Executes unit test cases | See compatibility table below | 2.16, devel, stable-2.17, stable-2.18, stable-2.19, stable-2.20 |
-| [Integration](.github/workflows/integration.yml) | Executes integration test suites | 3.12 | devel, stable-2.18, stable-2.19 |
+| Workflow | Jobs | Description | Python Versions | ansible-core Versions |
+| -------- | ---- | ----------- | --------------- | --------------------- |
+| [tests.yml](.github/workflows/tests.yml) | changelog | Checks for changelog fragments (skip with `skip-changelog` label) | Latest Ubuntu runner | N/A |
+| [tests.yml](.github/workflows/tests.yml) | build-import | Validates collection build via galaxy-importer | Latest Ubuntu runner | Latest stable |
+| [tests.yml](.github/workflows/tests.yml) | ansible-lint | Runs ansible-lint on collection content | 3.14 | Latest available |
+| [tests.yml](.github/workflows/tests.yml) | sanity | Runs ansible-test sanity checks via tox-ansible | 3.10, 3.11, 3.12 | 2.16 |
+| [tests.yml](.github/workflows/tests.yml) | unit-galaxy | Executes unit tests via ansible-test and tox-ansible | 3.10, 3.11, 3.12 | 2.16 |
+| [tests.yml](.github/workflows/tests.yml) | unit-source | Executes pytest unit tests from source | 3.10-3.14 (see exclusions) | 2.16-2.20, devel |
+| [linters.yml](.github/workflows/linters.yml) | linters | Runs `black`, `flake8`, and `isort` via tox | 3.11 | N/A |
+| [integration.yml](.github/workflows/integration.yml) | run-integration-tests | Executes integration test suites against live Vault | 3.12 | devel, stable-2.18, stable-2.19 |
 
-**Note:** Integration tests require a live HashiCorp Vault instance and use GitHub secrets for authentication.
+**Notes:**
+- Integration tests require a live HashiCorp Vault instance. The workflow uses GitHub secrets (`VAULT_ADDR`, `VAULT_APPROLE_ROLE_ID`, `VAULT_APPROLE_SECRET_ID`) and targets the `admin/hashicorp-vault-integration-tests` namespace.
+- The collection's [tox.ini](tox.ini) file defines linting environments only. Unit and integration tests are run via ansible-test in GitHub Actions workflows, not through tox.
 
 ### Python Version Compatibility by ansible-core Version
 
-These are outlined in the collection's [tox.ini](tox.ini) file (`envlist`) and GitHub Actions workflow exclusions.
+These are defined in the GitHub Actions workflow matrix configurations, not in tox.ini.
 
-| ansible-core Version | Sanity Tests | Unit Tests |
-| -------------------- | ------------ | ---------- |
-| 2.16 | 3.10, 3.11, 3.12 | 3.10, 3.11, 3.12 |
+**Sanity and Unit-Galaxy Tests** (via tox-ansible):
+| ansible-core Version | Python Versions |
+| -------------------- | --------------- |
+| 2.16 | 3.10, 3.11, 3.12 |
+
+**Unit-Source Tests** (pytest from source):
+| ansible-core Version | Python Versions |
+| -------------------- | --------------- |
+| 2.16 | 3.10, 3.11 |
+| 2.17 | 3.10, 3.11, 3.12 |
+| 2.18 | 3.11, 3.12, 3.13 |
+| 2.19 | 3.11, 3.12, 3.13 |
+| 2.20 | 3.12, 3.13 |
+| devel | 3.12, 3.13 |
+
+**Integration Tests**:
+| ansible-core Version | Python Versions |
+| -------------------- | --------------- |
+| devel | 3.12 |
+| stable-2.18 | 3.12 |
+| stable-2.19 | 3.12 |
+
+**Notes:**
+- The `unit-source` workflow uses reusable workflows from `ansible-network/github_actions` which tests against a comprehensive matrix
+- Version combinations follow ansible-core's official Python support matrix
+- The `unit-galaxy` workflow uses tox-ansible with explicit matrix entries only for 2.16
+- All workflows use matrix exclusions to prevent unsupported Python/ansible-core combinations


### PR DESCRIPTION
##### SUMMARY                                                                                                                                                              
Add a new CI.md file to document the collection's continuous integration setup and testing processes. This documentation provides transparency about:                      
- GitHub Actions workflows used for PR testing (changelog, linters, sanity, unit tests, integration tests)                                                                 
- Python version compatibility matrix for different ansible-core versions                                                                                                  
- Integration test requirements and configuration                                                                                                                          
                                                                                                                                                                            
This helps contributors understand which tests will run on their PRs and the supported version combinations.                                                               
                                                                                                                                                                            
##### ISSUE TYPE                                                                                                                                                           
- Docs Pull Request
                                                                                                                                                                            
##### COMPONENT NAME
CI.md                                                                                                                                                                      
                
##### ADDITIONAL INFORMATION                                                                                                                                               
The CI.md file follows a similar structure to other Ansible collections (like amazon.aws) for consistency across the ecosystem. It consolidates information about:
- Testing workflows with links to workflow files in the `.github/workflows` directory                                                                                      
- Python 3.10, 3.11, 3.12 support with ansible-core 2.16+                                                                                                                  
- Integration test requirements (live HashiCorp Vault instance with GitHub secrets for authentication)                                                                     
                                                                                                                                                                            
This documentation makes the CI process more transparent and easier for new contributors to understand.
