### PR TITLE
[Manual Backport][Stable-1] add label_bugfix_release to backport (#26)

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,3 +19,4 @@ jobs:
     uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@main
     with:
       label_minor_release: backport-1
+      label_bugfix_release: backport-1


### PR DESCRIPTION
## Summary

Backport of #26 to stable-1 branch.

**Original PR:** https://github.com/ansible-collections/hashicorp.vault/pull/26

## Changes

- Adds `label_bugfix_release` label to backport workflow configuration

## Cherry-pick info

```
(cherry picked from commit 60f7eca3ee2b9c8f1c0e6a4e6c96d15f8c5f2c0d)
```

---
🤖 Manual backport created for stable-1