### PR TITLE
[Backport][Stable-1] ACA-5282: namespace write utils (#55)

### DIFF
--- a/changelogs/fragments/20260320-namespace-write-utils.yaml
+++ b/changelogs/fragments/20260320-namespace-write-utils.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - module_utils/vault_client.py - extended ``VaultNamespaces`` with ``create_namespace()``,
+    ``patch_namespace()``, ``delete_namespace()``, ``lock_namespace()``, and ``unlock_namespace()``
+    for managing namespace lifecycle and API locks
+    (https://github.com/ansible-collections/hashicorp.vault/pull/55).

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -524,8 +524,8 @@ class VaultNamespaces:
     """
     Handles interactions with the Vault Namespaces API (/sys/namespaces).
 
-    Provides read-only operations for listing and reading namespace information.
-    Used by the namespaces _info Ansible module.
+    Provides operations for listing, reading, creating, patching, deleting,
+    locking, and unlocking namespaces.
     """
 
     def __init__(self, client):
@@ -570,6 +570,142 @@ class VaultNamespaces:
         path = f"v1/sys/namespaces/{namespace_path}"
         response = self._client._make_request("GET", path)
         return response.get("data", {})
+
+    def create_namespace(self, namespace_path: str, custom_metadata: Optional[Dict[str, str]] = None) -> dict:
+        """
+        Create a new Vault namespace.
+
+        Args:
+            namespace_path (str): The path for the new namespace.
+            custom_metadata (dict, optional): Custom metadata key-value pairs for the namespace.
+
+        Returns:
+            dict: Response data from Vault containing the created namespace information.
+
+        Raises:
+            TypeError: If custom_metadata is not a dict.
+
+        Example:
+            namespaces.create_namespace(
+                namespace_path="engineering/",
+                custom_metadata={"team": "platform", "environment": "prod"}
+            )
+        """
+        if custom_metadata is not None and not isinstance(custom_metadata, dict):
+            raise TypeError("custom_metadata must be a dict")
+
+        path = f"v1/sys/namespaces/{namespace_path}"
+        body: Dict[str, Any] = {}
+        if custom_metadata:
+            body["custom_metadata"] = custom_metadata
+
+        logger.debug("POST namespace at %s", namespace_path)
+        return self._client._make_request("POST", path, json=body)
+
+    def patch_namespace(self, namespace_path: str, custom_metadata: Optional[Dict[str, str]] = None) -> dict:
+        """
+        Patch an existing Vault namespace's custom metadata.
+
+        Args:
+            namespace_path (str): The path of the namespace to patch.
+            custom_metadata (dict, optional): Custom metadata key-value pairs to merge.
+
+        Returns:
+            dict: Response data from Vault.
+
+        Raises:
+            TypeError: If custom_metadata is not a dict.
+
+        Example:
+            namespaces.patch_namespace(
+                namespace_path="engineering/",
+                custom_metadata={"owner": "alice"}
+            )
+        """
+        if custom_metadata is not None and not isinstance(custom_metadata, dict):
+            raise TypeError("custom_metadata must be a dict")
+
+        path = f"v1/sys/namespaces/{namespace_path}"
+        body: Dict[str, Any] = {}
+        if custom_metadata:
+            body["custom_metadata"] = custom_metadata
+
+        headers = {"Content-Type": "application/merge-patch+json"}
+
+        logger.debug("PATCH namespace at %s", namespace_path)
+        return self._client._make_request("PATCH", path, json=body, headers=headers)
+
+    def delete_namespace(self, namespace_path: str) -> None:
+        """
+        Delete a Vault namespace.
+
+        Args:
+            namespace_path (str): The path of the namespace to delete.
+
+        Returns:
+            None
+        """
+        path = f"v1/sys/namespaces/{namespace_path}"
+        self._client._make_request("DELETE", path)
+
+    def lock_namespace(self, subpath: Optional[str] = None) -> dict:
+        """
+        Lock a namespace to prevent API operations.
+
+        Args:
+            subpath (str, optional): Subpath within the namespace to lock. If None, locks the current namespace.
+
+        Returns:
+            dict: Response data from Vault containing lock information (e.g., unlock_key).
+
+        Example:
+            # Lock current namespace
+            result = namespaces.lock_namespace()
+            unlock_key = result.get("unlock_key")
+
+            # Lock a subpath
+            result = namespaces.lock_namespace(subpath="child/")
+        """
+        if subpath:
+            path = f"v1/sys/namespaces/api-lock/lock/{subpath}"
+        else:
+            path = "v1/sys/namespaces/api-lock/lock"
+
+        logger.debug("POST lock namespace at %s", path)
+        return self._client._make_request("POST", path, json={})
+
+    def unlock_namespace(self, subpath: Optional[str] = None, unlock_key: Optional[str] = None) -> dict:
+        """
+        Unlock a namespace to restore API operations.
+
+        Args:
+            subpath (str, optional): Subpath within the namespace to unlock. If None, unlocks the current namespace.
+            unlock_key (str, optional): The unlock key obtained from lock_namespace(). Root token holders can omit this.
+
+        Returns:
+            dict: Response data from Vault.
+
+        Example:
+            # Unlock with key
+            namespaces.unlock_namespace(unlock_key="abc123...")
+
+            # Unlock as root (no key needed)
+            namespaces.unlock_namespace()
+
+            # Unlock a subpath
+            namespaces.unlock_namespace(subpath="child/", unlock_key="abc123...")
+        """
+        if subpath:
+            path = f"v1/sys/namespaces/api-lock/unlock/{subpath}"
+        else:
+            path = "v1/sys/namespaces/api-lock/unlock"
+
+        body: Dict[str, Any] = {}
+        if unlock_key:
+            body["unlock_key"] = unlock_key
+
+        logger.debug("POST unlock namespace at %s", path)
+        return self._client._make_request("POST", path, json=body)
 
 
 class Secrets:

--- a/tests/unit/plugins/module_utils/test_vault_namespaces.py
+++ b/tests/unit/plugins/module_utils/test_vault_namespaces.py
@@ -150,3 +150,260 @@ class TestVaultReadNamespace:
         result = namespaces.read_namespace('minimal/')
 
         assert result['custom_metadata'] is None
+
+
+class TestVaultCreateNamespace:
+    """Test the create_namespace method of the VaultNamespaces class."""
+
+    def test_create_namespace_with_metadata(self, authenticated_client):
+        """Test creating a namespace with custom metadata."""
+        response = {'data': {'id': 'new-id', 'path': 'engineering/'}}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+        custom_metadata = {'team': 'platform', 'environment': 'prod'}
+
+        result = namespaces.create_namespace('engineering/', custom_metadata=custom_metadata)
+
+        expected_path = 'v1/sys/namespaces/engineering/'
+        authenticated_client._make_request.assert_called_once_with(
+            'POST', expected_path, json={'custom_metadata': custom_metadata}
+        )
+        assert result == response
+
+    def test_create_namespace_without_metadata(self, authenticated_client):
+        """Test creating a namespace without custom metadata."""
+        response = {'data': {'id': 'new-id', 'path': 'qa/'}}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.create_namespace('qa/')
+
+        expected_path = 'v1/sys/namespaces/qa/'
+        authenticated_client._make_request.assert_called_once_with('POST', expected_path, json={})
+        assert result == response
+
+    def test_create_namespace_with_none_metadata(self, authenticated_client):
+        """Test creating a namespace with None as metadata."""
+        response = {'data': {'id': 'new-id', 'path': 'dev/'}}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.create_namespace('dev/', custom_metadata=None)
+
+        expected_path = 'v1/sys/namespaces/dev/'
+        authenticated_client._make_request.assert_called_once_with('POST', expected_path, json={})
+        assert result == response
+
+    def test_create_namespace_invalid_metadata_type(self, authenticated_client):
+        """Test creating a namespace with invalid metadata type."""
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(TypeError, match='custom_metadata must be a dict'):
+            namespaces.create_namespace('test/', custom_metadata='invalid')
+
+    def test_create_namespace_error(self, authenticated_client):
+        """Test creating a namespace with an error response."""
+        authenticated_client._make_request.side_effect = VaultPermissionError('error creating namespace')
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(VaultPermissionError):
+            namespaces.create_namespace('forbidden/')
+
+
+class TestVaultPatchNamespace:
+    """Test the patch_namespace method of the VaultNamespaces class."""
+
+    def test_patch_namespace_success(self, authenticated_client):
+        """Test patching a namespace with custom metadata."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+        custom_metadata = {'owner': 'alice', 'cost_center': '1234'}
+
+        result = namespaces.patch_namespace('engineering/', custom_metadata)
+
+        expected_path = 'v1/sys/namespaces/engineering/'
+        authenticated_client._make_request.assert_called_once_with(
+            'PATCH',
+            expected_path,
+            json={'custom_metadata': custom_metadata},
+            headers={'Content-Type': 'application/merge-patch+json'},
+        )
+        assert result == response
+
+    def test_patch_namespace_without_metadata(self, authenticated_client):
+        """Test patching a namespace without custom metadata."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.patch_namespace('engineering/')
+
+        expected_path = 'v1/sys/namespaces/engineering/'
+        authenticated_client._make_request.assert_called_once_with(
+            'PATCH', expected_path, json={}, headers={'Content-Type': 'application/merge-patch+json'}
+        )
+        assert result == response
+
+    def test_patch_namespace_with_none_metadata(self, authenticated_client):
+        """Test patching a namespace with None as metadata."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.patch_namespace('engineering/', custom_metadata=None)
+
+        expected_path = 'v1/sys/namespaces/engineering/'
+        authenticated_client._make_request.assert_called_once_with(
+            'PATCH', expected_path, json={}, headers={'Content-Type': 'application/merge-patch+json'}
+        )
+        assert result == response
+
+    def test_patch_namespace_invalid_metadata_type(self, authenticated_client):
+        """Test patching a namespace with invalid metadata type."""
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(TypeError, match='custom_metadata must be a dict'):
+            namespaces.patch_namespace('test/', custom_metadata='invalid')
+
+    def test_patch_namespace_not_found(self, authenticated_client):
+        """Test patching a non-existent namespace."""
+        authenticated_client._make_request.side_effect = VaultSecretNotFoundError('namespace not found')
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(VaultSecretNotFoundError):
+            namespaces.patch_namespace('nonexistent/', {'key': 'value'})
+
+
+class TestVaultDeleteNamespace:
+    """Test the delete_namespace method of the VaultNamespaces class."""
+
+    def test_delete_namespace_success(self, authenticated_client):
+        """Test deleting a namespace."""
+        authenticated_client._make_request.return_value = {}
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.delete_namespace('old-namespace/')
+
+        expected_path = 'v1/sys/namespaces/old-namespace/'
+        authenticated_client._make_request.assert_called_once_with('DELETE', expected_path)
+        assert result is None
+
+    def test_delete_namespace_not_found(self, authenticated_client):
+        """Test deleting a non-existent namespace."""
+        authenticated_client._make_request.side_effect = VaultSecretNotFoundError('namespace not found')
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(VaultSecretNotFoundError):
+            namespaces.delete_namespace('nonexistent/')
+
+    def test_delete_namespace_permission_error(self, authenticated_client):
+        """Test deleting a namespace with insufficient permissions."""
+        authenticated_client._make_request.side_effect = VaultPermissionError('permission denied')
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(VaultPermissionError):
+            namespaces.delete_namespace('protected/')
+
+
+class TestVaultLockNamespace:
+    """Test the lock_namespace method of the VaultNamespaces class."""
+
+    def test_lock_namespace_current(self, authenticated_client):
+        """Test locking the current namespace."""
+        response = {'unlock_key': 'test-unlock-key-123'}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.lock_namespace()
+
+        expected_path = 'v1/sys/namespaces/api-lock/lock'
+        authenticated_client._make_request.assert_called_once_with('POST', expected_path, json={})
+        assert result == response
+        assert result['unlock_key'] == 'test-unlock-key-123'
+
+    def test_lock_namespace_with_subpath(self, authenticated_client):
+        """Test locking a namespace subpath."""
+        response = {'unlock_key': 'subpath-unlock-key'}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.lock_namespace(subpath='child/')
+
+        expected_path = 'v1/sys/namespaces/api-lock/lock/child/'
+        authenticated_client._make_request.assert_called_once_with('POST', expected_path, json={})
+        assert result == response
+
+    def test_lock_namespace_error(self, authenticated_client):
+        """Test locking a namespace with an error response."""
+        authenticated_client._make_request.side_effect = VaultPermissionError('cannot lock namespace')
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(VaultPermissionError):
+            namespaces.lock_namespace()
+
+
+class TestVaultUnlockNamespace:
+    """Test the unlock_namespace method of the VaultNamespaces class."""
+
+    def test_unlock_namespace_with_key(self, authenticated_client):
+        """Test unlocking the current namespace with an unlock key."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+        unlock_key = 'test-unlock-key-123'
+
+        result = namespaces.unlock_namespace(unlock_key=unlock_key)
+
+        expected_path = 'v1/sys/namespaces/api-lock/unlock'
+        authenticated_client._make_request.assert_called_once_with(
+            'POST', expected_path, json={'unlock_key': unlock_key}
+        )
+        assert result == response
+
+    def test_unlock_namespace_without_key(self, authenticated_client):
+        """Test unlocking as root (no key needed)."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.unlock_namespace()
+
+        expected_path = 'v1/sys/namespaces/api-lock/unlock'
+        authenticated_client._make_request.assert_called_once_with('POST', expected_path, json={})
+        assert result == response
+
+    def test_unlock_namespace_with_subpath(self, authenticated_client):
+        """Test unlocking a namespace subpath."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+        unlock_key = 'subpath-unlock-key'
+
+        result = namespaces.unlock_namespace(subpath='child/', unlock_key=unlock_key)
+
+        expected_path = 'v1/sys/namespaces/api-lock/unlock/child/'
+        authenticated_client._make_request.assert_called_once_with(
+            'POST', expected_path, json={'unlock_key': unlock_key}
+        )
+        assert result == response
+
+    def test_unlock_namespace_subpath_without_key(self, authenticated_client):
+        """Test unlocking a subpath as root (no key needed)."""
+        response = {}
+        authenticated_client._make_request.return_value = response
+        namespaces = VaultNamespaces(authenticated_client)
+
+        result = namespaces.unlock_namespace(subpath='child/')
+
+        expected_path = 'v1/sys/namespaces/api-lock/unlock/child/'
+        authenticated_client._make_request.assert_called_once_with('POST', expected_path, json={})
+        assert result == response
+
+    def test_unlock_namespace_error(self, authenticated_client):
+        """Test unlocking a namespace with an error response."""
+        authenticated_client._make_request.side_effect = VaultPermissionError('cannot unlock namespace')
+        namespaces = VaultNamespaces(authenticated_client)
+
+        with pytest.raises(VaultPermissionError):
+            namespaces.unlock_namespace(unlock_key='invalid-key')


### PR DESCRIPTION
## Summary
Backport of PR #55 to stable-1

This adds namespace write utilities including create, patch, delete, lock, and unlock functions with associated tests.

Clean cherry-pick with no conflicts.

## Test plan
- [x] Clean cherry-pick from main
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)