### PR TITLE
[Backport][Stable-1] Add modules for ACL policy management (#52)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Name | Description
 [hashicorp.vault.kv2_secret_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret_info.py)|Read HashiCorp Vault KV version 2 secrets
 [hashicorp.vault.kv1_secret](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv1_secret.py)|Manage HashiCorp Vault KV version 1 secrets
 [hashicorp.vault.kv1_secret_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv1_secret_info.py)|Read HashiCorp Vault KV version 1 secrets
+[hashicorp.vault.acl_policy](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/acl_policy.py)|Manage HashiCorp Vault ACL policies
+[hashicorp.vault.acl_policy_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/acl_policy_info.py)|List and read HashiCorp Vault ACL policies
 
 ## Installation
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -2,6 +2,8 @@
 requires_ansible: ">=2.16.0"
 action_groups:
   vault:
+    - acl_policy
+    - acl_policy_info
     - kv1_secret_info
     - kv1_secret
     - kv2_secret_info

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -462,18 +462,20 @@ class VaultAclPolicies:
 
     def list_acl_policies(self) -> List[str]:
         """
-        List all Vault ACL policy names.
+        List all Vault ACL policy names via GET /sys/policy.
 
         Returns:
-            list: ACL policy names (e.g. ["root", "deploy"]).
+            list: ACL policy names sorted lexicographically.
         """
-        path = "v1/sys/policy"
-        response = self._client._make_request("GET", path)
-        return response.get("policies", [])
+        response = self._client._make_request("GET", "v1/sys/policy")
+        # HCP commonly returns top-level "policies"; keeping a small fallback for data.policies.
+        names = response.get("policies") or response.get("data", {}).get("policies") or []
+        names = [name for name in names if isinstance(name, str)]
+        return sorted(names)
 
     def read_acl_policy(self, name: str) -> dict:
         """
-        Read a Vault ACL policy by name.
+        Read a Vault ACL policy by name via GET /sys/policy/:name.
 
         Args:
             name (str): The name of the ACL policy to read.
@@ -482,7 +484,10 @@ class VaultAclPolicies:
             dict: ACL policy data with "name" and "rules" keys.
         """
         path = f"v1/sys/policy/{name}"
-        return self._client._make_request("GET", path)
+        raw = self._client._make_request("GET", path)
+        data = raw.get("data") or {}
+        rules = raw.get("rules") or raw.get("policy") or data.get("rules") or data.get("policy") or ""
+        return {"name": name, "rules": rules.strip()}
 
     def create_or_update_acl_policy(self, name: str, acl_policy_rules: str) -> dict:
         """

--- a/plugins/modules/acl_policy.py
+++ b/plugins/modules/acl_policy.py
@@ -1,0 +1,188 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: acl_policy
+short_description: Manage HashiCorp Vault ACL policies
+version_added: 1.2.0
+author: Mandar Kulkarni (@mandar242)
+description:
+  - Create, update, or delete ACL policies via C(/sys/policy).
+  - For read-only operations, use M(hashicorp.vault.acl_policy_info).
+  - Uses the collection's shared connection and authentication options; HTTP calls are handled by the ACL policy client on the Vault client.
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+options:
+  name:
+    description:
+      - Name of the ACL policy (URL path segment for C(/sys/policy/:name)).
+    type: str
+    required: true
+  policy:
+    description:
+      - Policy document as a string (HCL rules body sent as the C(policy) field in the Vault API).
+      - Required when O(state=present).
+    type: str
+    aliases: [rules]
+  state:
+    description:
+      - V(present) creates the policy or updates it when the rules differ from the desired document.
+      - V(absent) removes the policy. Deleting a non-existent policy succeeds with C(changed=false).
+    type: str
+    choices: [present, absent]
+    default: present
+"""
+
+EXAMPLES = """
+- name: Create or update an ACL policy
+  hashicorp.vault.acl_policy:
+    url: https://vault.example.com:8200
+    token: "{{ vault_token }}"
+    name: my-app-policy
+    policy: |
+      path "secret/data/myapp/*" {
+        capabilities = ["read", "list"]
+      }
+
+- name: Same policy using rules alias
+  hashicorp.vault.acl_policy:
+    url: https://vault.example.com:8200
+    name: deploy-policy
+    rules: |
+      path "secret/data/deploy/*" {
+        capabilities = ["read", "update", "create"]
+      }
+
+- name: Remove an ACL policy
+  hashicorp.vault.acl_policy:
+    url: https://vault.example.com:8200
+    name: old-policy
+    state: absent
+"""
+
+RETURN = """
+msg:
+  description: Human-readable result message.
+  returned: always
+  type: str
+raw:
+  description: Raw JSON response from Vault on create/update (often empty).
+  returned: when I(state=present) and the policy was created or updated
+  type: dict
+"""
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def ensure_policy_present(module: AnsibleModule, client) -> None:
+    name = module.params["name"]
+    desired_rules = module.params["policy"]
+
+    action = "created"
+    try:
+        existing = client.acl_policies.read_acl_policy(name)
+        current_rules = existing.get("rules", "")
+        if current_rules == desired_rules:
+            module.exit_json(
+                changed=False,
+                msg="ACL policy already exists with the same rules",
+            )
+        action = "updated"
+    except VaultSecretNotFoundError:
+        pass
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            msg=f"Would have {action} ACL policy {name!r} if not in check mode.",
+        )
+
+    raw = client.acl_policies.create_or_update_acl_policy(name, desired_rules)
+    module.exit_json(
+        changed=True,
+        msg=f"ACL policy {name!r} {action} successfully",
+        raw=raw or {},
+    )
+
+
+def ensure_policy_absent(module: AnsibleModule, client) -> None:
+    name = module.params["name"]
+
+    # Use read for idempotency: Vault may return success on DELETE even when the
+    # policy is already gone (e.g. HCP), so we cannot rely on 404 from delete alone.
+    try:
+        client.acl_policies.read_acl_policy(name)
+    except VaultSecretNotFoundError:
+        module.exit_json(
+            changed=False,
+            msg=f"ACL policy {name!r} already absent",
+        )
+
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            msg=f"Would have deleted ACL policy {name!r} if not in check mode.",
+        )
+
+    client.acl_policies.delete_acl_policy(name)
+    module.exit_json(
+        changed=True,
+        msg=f"ACL policy {name!r} deleted successfully",
+    )
+
+
+def main():
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            name=dict(type="str", required=True),
+            policy=dict(type="str", aliases=["rules"]),
+            state=dict(type="str", choices=["present", "absent"], default="present"),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=[("state", "present", ["policy"])],
+        supports_check_mode=True,
+    )
+
+    client = get_authenticated_client(module)
+    state = module.params["state"]
+
+    try:
+        if state == "present":
+            ensure_policy_present(module, client)
+        else:
+            ensure_policy_absent(module, client)
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except TypeError as e:
+        module.fail_json(msg=str(e))
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/acl_policy_info.py
+++ b/plugins/modules/acl_policy_info.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: acl_policy_info
+short_description: List and read HashiCorp Vault ACL policies
+version_added: 1.2.0
+author: Mandar Kulkarni (@mandar242)
+description:
+  - Query Vault ACL policies via the C(/sys/policy) API (list names or read one policy).
+  - Omit I(name) to list all policy names.
+  - Set I(name) to read that policy's C(name) and C(rules).
+options:
+  name:
+    description:
+      - ACL policy name to read. When omitted, lists all policy names.
+    type: str
+    required: false
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+"""
+
+EXAMPLES = """
+- name: List all ACL policy names (register for later tasks)
+  hashicorp.vault.acl_policy_info:
+    url: https://vault.example.com:8200
+    token: "{{ vault_token }}"
+  register: vault_acl_policies
+
+- name: Show policy names from registered result
+  ansible.builtin.debug:
+    msg: "{{ vault_acl_policies.policies | map(attribute='name') | list }}"
+
+- name: Read a single ACL policy (name and HCL rules)
+  hashicorp.vault.acl_policy_info:
+    url: https://vault.example.com:8200
+    token: "{{ vault_token }}"
+    name: my-app-policy
+  register: vault_policy_doc
+
+- name: Use policy rules in a demo or template
+  ansible.builtin.debug:
+    msg: "{{ vault_policy_doc.policies[0].rules }}"
+"""
+
+RETURN = """
+policies:
+  description:
+    - List of policy objects returned by C(acl_policy_info).
+    - Without I(name), each entry includes C(name).
+    - With I(name), the single entry includes C(name) and C(rules).
+  returned: always
+  type: list
+  elements: dict
+  sample:
+    - name: "my-policy"
+      rules: |
+        path "secret/data/myapp/*" {
+          capabilities = ["read", "list"]
+        }
+"""
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def main():
+
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            name=dict(type="str"),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    # Get authenticated client
+    client = get_authenticated_client(module)
+    name = module.params.get("name")
+
+    try:
+        if name:
+            data = client.acl_policies.read_acl_policy(name)
+            module.exit_json(
+                changed=False,
+                policies=[{"name": name, "rules": data.get("rules", "")}],
+            )
+        else:
+            policy_names = client.acl_policies.list_acl_policies()
+            policies = [{"name": policy_name} for policy_name in policy_names]
+            module.exit_json(changed=False, policies=policies)
+
+    except VaultSecretNotFoundError:
+        module.exit_json(changed=False, policies=[])
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/acl_policy/defaults/main.yml
+++ b/tests/integration/targets/acl_policy/defaults/main.yml
@@ -1,0 +1,11 @@
+---
+# Unique policy name per integration run (avoid collisions in shared Vault)
+# https://github.com/hashicorp/vault/issues/13647
+# Vault normalizes ACL policy names to lowercase across API responses.
+# Lowercase the generated suffix up front to keep integration assertions stable.
+acl_policy_test_name: "ansible-acl-int-{{ vault_resource_suffix | lower }}"
+
+# Single-line HCL improves round-trip equality with Vault's policy read API
+acl_policy_initial_rules: 'path "secret/data/ansible_acl_int/{{ vault_resource_suffix }}/*" { capabilities = ["read", "list"] }'
+
+acl_policy_updated_rules: 'path "secret/data/ansible_acl_int/{{ vault_resource_suffix }}/*" { capabilities = ["read", "list", "update", "create"] }'

--- a/tests/integration/targets/acl_policy/meta/main.yml
+++ b/tests/integration/targets/acl_policy/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_auth_token

--- a/tests/integration/targets/acl_policy/tasks/main.yml
+++ b/tests/integration/targets/acl_policy/tasks/main.yml
@@ -1,0 +1,332 @@
+---
+# Integration tests: acl_policy (create/update/delete) + acl_policy_info (list/read)
+# Covers: list, create, read, update, delete, idempotency, check mode, rules alias
+- name: Run acl_policy / acl_policy_info tests
+  collections:
+    - hashicorp.vault
+  module_defaults:
+    group/hashicorp.vault.vault:
+      url: "{{ vault_url }}"
+      namespace: "{{ vault_namespace }}"
+      auth_method: token
+      token: "{{ vault_token_from_setup_auth_token }}"
+  vars:
+    acl_policy_rules_alias_name: "{{ acl_policy_test_name }}-rules-alias"
+  block:
+    # -------------------------------------------------------------------------
+    # Cleanup
+    # -------------------------------------------------------------------------
+    - name: Remove test policies if left from prior run
+      hashicorp.vault.acl_policy:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ acl_policy_test_name }}"
+        - "{{ acl_policy_rules_alias_name }}"
+      failed_when: false
+
+    # -------------------------------------------------------------------------
+    # LIST (acl_policy_info, no name) — before any create
+    # -------------------------------------------------------------------------
+    - name: List ACL policies before create
+      hashicorp.vault.acl_policy_info:
+      register: policies_before
+
+    - name: List in check mode (no changes expected)
+      hashicorp.vault.acl_policy_info:
+      register: policies_list_check
+      check_mode: true
+
+    - name: Assert list shape and check mode unchanged
+      ansible.builtin.assert:
+        that:
+          - policies_before.policies is defined
+          - policies_before.policies is iterable
+          - (policies_before.policies | select('mapping') | list | length) == (policies_before.policies | length)
+          - (policies_before.policies | selectattr('name', 'defined') | list | length) == (policies_before.policies | length)
+          - policies_list_check.policies is defined
+          - policies_list_check.policies is iterable
+          - (policies_list_check.policies | select('mapping') | list | length) == (policies_list_check.policies | length)
+          - (policies_list_check.policies | selectattr('name', 'defined') | list | length) == (policies_list_check.policies | length)
+          - policies_list_check is not changed
+
+    # -------------------------------------------------------------------------
+    # CREATE — check mode then real
+    # -------------------------------------------------------------------------
+    - name: Create ACL policy (check mode)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_initial_rules }}"
+      register: create_check
+      check_mode: true
+
+    - name: Assert create check mode
+      ansible.builtin.assert:
+        that:
+          - create_check is changed
+          - "'Would have created' in create_check.msg"
+
+    - name: Read missing policy after create check mode
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: read_missing
+
+    - name: Assert policy still absent after create check mode
+      ansible.builtin.assert:
+        that:
+          - read_missing.policies is defined
+          - read_missing.policies | length == 0
+
+    - name: Create ACL policy
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_initial_rules }}"
+      register: create_result
+
+    # -------------------------------------------------------------------------
+    # READ (acl_policy_info with name)
+    # -------------------------------------------------------------------------
+    - name: Read policy via acl_policy_info
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: policy_read
+
+    - name: Read policy in check mode
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: policy_read_check
+      check_mode: true
+
+    - name: Assert create and read
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+          - policy_read.policies[0].name == acl_policy_test_name
+          - policy_read.policies[0].rules == acl_policy_initial_rules
+          - policy_read_check is not changed
+          - policy_read_check.policies[0].rules == acl_policy_initial_rules
+
+    # -------------------------------------------------------------------------
+    # LIST — policy name appears after create
+    # -------------------------------------------------------------------------
+    - name: List ACL policies after create
+      hashicorp.vault.acl_policy_info:
+      register: policies_after_create
+
+    - name: Assert policy name in list
+      ansible.builtin.assert:
+        that:
+          - acl_policy_test_name in (policies_after_create.policies | map(attribute='name') | list)
+
+    # -------------------------------------------------------------------------
+    # IDEMPOTENCY — present, same rules (policy + check mode)
+    # -------------------------------------------------------------------------
+    - name: Present same ACL policy again (idempotent)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_initial_rules }}"
+      register: create_idem
+
+    - name: Present same rules in check mode (idempotent)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_initial_rules }}"
+      register: present_check_idem
+      check_mode: true
+
+    - name: Assert present idempotency
+      ansible.builtin.assert:
+        that:
+          - create_idem is not changed
+          - "'same rules' in create_idem.msg or 'already exists' in create_idem.msg"
+          - present_check_idem is not changed
+
+    # -------------------------------------------------------------------------
+    # UPDATE — check mode then real
+    # -------------------------------------------------------------------------
+    - name: Update ACL policy (check mode)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_updated_rules }}"
+      register: update_check
+      check_mode: true
+
+    - name: Assert update check mode
+      ansible.builtin.assert:
+        that:
+          - update_check is changed
+          - "'Would have updated' in update_check.msg"
+
+    - name: Rules still initial after update check mode
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: policy_still_initial
+
+    - name: Assert no update applied in check mode
+      ansible.builtin.assert:
+        that:
+          - policy_still_initial.policies[0].rules == acl_policy_initial_rules
+
+    - name: Update ACL policy
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_updated_rules }}"
+      register: update_result
+
+    - name: Read updated policy
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: policy_updated_read
+
+    - name: Assert update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - policy_updated_read.policies[0].rules == acl_policy_updated_rules
+
+    - name: Update with same rules (idempotent)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        policy: "{{ acl_policy_updated_rules }}"
+      register: update_idem
+
+    - name: Assert update idempotency
+      ansible.builtin.assert:
+        that:
+          - update_idem is not changed
+
+    # -------------------------------------------------------------------------
+    # DELETE — check mode, then real, list/read verify absent
+    # -------------------------------------------------------------------------
+    - name: Delete ACL policy (check mode)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        state: absent
+      register: delete_check
+      check_mode: true
+
+    - name: Assert delete check mode
+      ansible.builtin.assert:
+        that:
+          - delete_check is changed
+          - "'Would have deleted' in delete_check.msg"
+
+    - name: Policy still exists after delete check mode
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: policy_after_delete_check
+
+    - name: Assert policy still present after delete check mode
+      ansible.builtin.assert:
+        that:
+          - policy_after_delete_check.policies[0].name == acl_policy_test_name
+
+    - name: Delete ACL policy
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        state: absent
+      register: delete_result
+
+    - name: Assert delete changed
+      ansible.builtin.assert:
+        that:
+          - delete_result is changed
+
+    - name: Read deleted policy (should not exist)
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_test_name }}"
+      register: read_after_delete
+
+    - name: Assert read after delete returns no policies
+      ansible.builtin.assert:
+        that:
+          - read_after_delete.policies is defined
+          - read_after_delete.policies | length == 0
+
+    - name: List ACL policies after delete
+      hashicorp.vault.acl_policy_info:
+      register: policies_after_delete
+
+    - name: Assert deleted policy not in list
+      ansible.builtin.assert:
+        that:
+          - acl_policy_test_name not in (policies_after_delete.policies | map(attribute='name') | list)
+
+    - name: Delete absent policy (idempotent)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        state: absent
+      register: delete_idem
+
+    - name: Delete absent in check mode (idempotent)
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_test_name }}"
+        state: absent
+      register: delete_absent_check
+      check_mode: true
+
+    - name: Assert delete idempotency and absent check mode
+      ansible.builtin.assert:
+        that:
+          - delete_idem is not changed
+          - "'already absent' in delete_idem.msg"
+          - delete_absent_check is not changed
+          - "'already absent' in delete_absent_check.msg"
+
+    # -------------------------------------------------------------------------
+    # RULES alias (O(policy) alias) — full mini cycle
+    # -------------------------------------------------------------------------
+    - name: Create policy using rules alias
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_rules_alias_name }}"
+        rules: "{{ acl_policy_initial_rules }}"
+      register: alias_create
+
+    - name: Read alias policy
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_rules_alias_name }}"
+      register: alias_read
+
+    - name: Assert rules alias create and read
+      ansible.builtin.assert:
+        that:
+          - alias_create is changed
+          - alias_read.policies[0].rules == acl_policy_initial_rules
+
+    - name: Update using rules alias
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_rules_alias_name }}"
+        rules: "{{ acl_policy_updated_rules }}"
+      register: alias_update
+
+    - name: Read after alias update
+      hashicorp.vault.acl_policy_info:
+        name: "{{ acl_policy_rules_alias_name }}"
+      register: alias_read_updated
+
+    - name: Assert alias update
+      ansible.builtin.assert:
+        that:
+          - alias_update is changed
+          - alias_read_updated.policies[0].rules == acl_policy_updated_rules
+
+    - name: Remove alias test policy
+      hashicorp.vault.acl_policy:
+        name: "{{ acl_policy_rules_alias_name }}"
+        state: absent
+      register: alias_delete
+
+    - name: Assert alias delete
+      ansible.builtin.assert:
+        that:
+          - alias_delete is changed
+
+  always:
+    - name: Ensure test policies removed
+      hashicorp.vault.acl_policy:
+        name: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ acl_policy_test_name }}"
+        - "{{ acl_policy_rules_alias_name }}"
+      failed_when: false

--- a/tests/unit/plugins/module_utils/test_vault_acl_policies.py
+++ b/tests/unit/plugins/module_utils/test_vault_acl_policies.py
@@ -46,8 +46,21 @@ def test_list_acl_policies_success(authenticated_client):
     policies_client = VaultAclPolicies(authenticated_client)
     result = policies_client.list_acl_policies()
 
-    authenticated_client._make_request.assert_called_once_with("GET", "v1/sys/policy")
-    assert result == ["root", "deploy", "my-policy"]
+    assert authenticated_client._make_request.call_args_list[0] == (("GET", "v1/sys/policy"),)
+    assert result == ["deploy", "my-policy", "root"]
+
+
+def test_list_acl_policies_data_policies(authenticated_client):
+    """HCP Vault wraps policy names under data.policies."""
+    response = {"data": {"policies": ["default", "hcp-root", "my-policy"]}}
+    authenticated_client._make_request.return_value = response
+
+    policies_client = VaultAclPolicies(authenticated_client)
+    result = policies_client.list_acl_policies()
+
+    assert "my-policy" in result
+    assert "default" in result
+    assert "hcp-root" in result
 
 
 def test_list_acl_policies_empty_response(authenticated_client):


### PR DESCRIPTION
## Summary
Backport of PR #52 to stable-1

This adds modules for ACL policy management:
- `acl_policy` - Manage HashiCorp Vault ACL policies
- `acl_policy_info` - List and read HashiCorp Vault ACL policies

Cherry-pick with minor conflict in README.md (merged module table entries).

## Test plan
- [x] Resolved conflict in README.md
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)