### PR TITLE
[Backport][Stable-1] ACA-5051 ACA-5052 database_connection and database_connection_info modules (#50)

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -4,6 +4,8 @@ action_groups:
   vault:
     - acl_policy
     - acl_policy_info
+    - database_connection_info
+    - database_connection
     - kv1_secret_info
     - kv1_secret
     - kv2_secret_info

--- a/plugins/modules/database_connection.py
+++ b/plugins/modules/database_connection.py
@@ -1,0 +1,325 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: database_connection
+short_description: Manage database secrets engine connections in HashiCorp Vault.
+version_added: 1.2.0
+author: Aubin Bikouo (@abikouo)
+description:
+  - This module manages (create, update, delete, and reset) the lifecycle of database
+    connection configurations within the HashiCorp Vault Database secrets engine.
+options:
+  state:
+    description:
+      - Goal state for the database connection.
+      - Use V(present) to create or update the connection.
+      - Use V(reset) to trigger a connection reset.
+      - Use V(absent) to remove the connection configuration.
+    choices: [present, absent, reset]
+    default: present
+    type: str
+  database_mount_path:
+    description: Database secret engine mount path.
+    type: str
+    default: database
+    aliases: [vault_database_mount_path]
+  name:
+    description: The name of the database connection configuration.
+    required: true
+    type: str
+    aliases: [connection_name]
+  username:
+    description:
+      - The username to connect to the database.
+    required: false
+    type: str
+    aliases: [connection_username]
+  password:
+    description:
+      - The password to connect to the database.
+    required: false
+    type: str
+    aliases: [connection_password]
+  disable_escaping:
+    description: Determines whether special characters in the username and password fields will be escaped.
+    type: bool
+    default: false
+  connection_url:
+    description: The connection string used to connect to the database.
+    type: str
+  plugin_name:
+    description:
+      - The name of the plugin to use for this connection.
+      - Required when O(state=present).
+    required: false
+    type: str
+  plugin_version:
+    description:
+      - The semantic version of the plugin to use for this connection.
+    type: str
+    required: false
+  plugin_options:
+    description:
+      - Additional parameters specific to the plugin.
+      - This should be a dictionary of options required by the specific database plugin.
+    type: dict
+  verify_connection:
+    description: Specifies if the connection is verified during initial configuration.
+    default: true
+    type: bool
+  allowed_roles:
+    description: A list of roles authorized to use this connection.
+    type: list
+    elements: str
+  root_rotation_statements:
+    description:
+      - Specifies the database statements to be executed to rotate the root user's credentials.
+      - Refer to the specific Vault database plugin documentation for supported formatting.
+    type: list
+    elements: str
+  password_policy:
+    description:
+      - The name of the password policy to use when generating passwords for this database.
+      - If not specified, Vault uses a default policy (20 characters, mixed case, number, dash).
+    type: str
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+"""
+
+EXAMPLES = """
+- name: Create database connection with PostgreSQL plugin
+  hashicorp.vault.database_connection:
+    name: postgres-sample-connection
+    plugin_name: "postgresql-database-plugin"
+    allowed_roles:
+      - "readonly"
+    connection_url: "host=localhost port=5432 user='{{ username }}' password='{{ password }}'"
+    plugin_options:
+      max_open_connections: 5
+      max_connection_lifetime: "5s"
+    username: "admin_user"
+    password: "secure_password"
+
+- name: Update a database connection with MySQL
+  hashicorp.vault.database_connection:
+    name: mysql-sample-connection
+    state: present
+    connection_url: "mysql://vaultuser:secretpassword@localhost:3306/mydb"
+    verify_connection: true
+    plugin_name: "mysql-database-plugin"
+    database_mount_path: "database-conn-config-integration-tests"
+    allowed_roles:
+      - "readonly"
+      - "readwrite"
+    username: "vaultuser"
+    password: "secretpassword"
+
+- name: Reset a database connection
+  hashicorp.vault.database_connection:
+    name: mysql-sample-connection
+    state: reset
+
+- name: Delete a database connection
+  hashicorp.vault.database_connection:
+    name: mysql-sample-connection
+    state: absent
+"""
+
+RETURN = """
+msg:
+  description: A message describing the result of the operation.
+  returned: always
+  type: str
+raw:
+  description: The configuration settings for the database connection created/updated.
+  returned: When I(state=present) or I(state=reset)
+  type: dict
+  sample:
+    {
+        "allowed_roles": ["readonly"],
+        "connection_details": {
+            "connection_url": "dbuser:dbpassword123@tcp(127.0.0.1:3306)/",
+            "username": "vaultuser"
+        },
+        "password_policy": "",
+        "plugin_name": "mysql-database-plugin",
+        "plugin_version": "",
+        "root_credentials_rotate_statements": [],
+        "skip_static_role_import_rotation": false
+    }
+"""
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+    VaultDatabaseConnection,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def read_connection(db_conn: VaultDatabaseConnection, name: str) -> dict:
+    """
+    Read database connection.
+
+    Args:
+        db_conn (VaultDatabaseConnection): The database connection object.
+        name (str): The name of the connection to read.
+
+    Returns:
+        dict: A dict containing the connection details, empty when the connection does not exist.
+    """
+    try:
+        return db_conn.read_connection(name=name)
+    except VaultSecretNotFoundError as e:
+        return {}
+
+
+def perform_action(module: AnsibleModule) -> tuple[bool, dict]:
+    """
+    Create/update/delete/reset database connection based on parameters.
+
+    Args:
+        module (str): The ansible module object.
+
+    Returns:
+        (bool, dict): A tuple containing a boolean flag—indicating whether
+        the module performed any changes—and a dictionary representing the JSON-structured result.
+    """
+
+    # Get authenticated client
+    client = get_authenticated_client(module)
+    mount_path = module.params.get("database_mount_path")
+    name = module.params.get("name")
+
+    db_conn = VaultDatabaseConnection(client, mount_path=mount_path)
+    state = module.params.get("state")
+
+    changed = False
+    result = {}
+
+    # Read existing database configuration
+    existing = read_connection(db_conn, name)
+    if state == "present":
+        config_params = (
+            "plugin_name",
+            "plugin_version",
+            "allowed_roles",
+            "verify_connection",
+            "root_rotation_statements",
+            "password_policy",
+            "connection_url",
+            "username",
+            "password",
+            "disable_escaping",
+        )
+        config = {key: module.params.get(key) for key in config_params}
+        plugin_options = module.params.get("plugin_options")
+        if plugin_options:
+            config.update(plugin_options)
+        if module.check_mode:
+            changed = True
+            operation = "updated" if existing else "created"
+            result['msg'] = f"Would have {operation} database connection '{name}' if not in check mode"
+            return changed, result
+
+        # Create/update database connection
+        result = db_conn.create_or_update_connection(name, config)
+
+        # read connection
+        result["raw"] = read_connection(db_conn, name)
+
+        # check idempotency to ensure change
+        changed = not (result['raw'] == existing)
+        if not changed:
+            result['msg'] = "The database connection with these settings is already configured."
+        else:
+            action = "updated" if existing else "created"
+            result['msg'] = f"The database connection has been successfully {action}."
+
+    elif state == "reset":
+        # state == 'reset' reset the connection if it exists
+        if existing:
+            changed = True
+            result["msg"] = f"Would have reset the database connection '{name}' if not in check mode."
+            if not module.check_mode:
+                db_conn.reset_connection(name)
+                result["msg"] = f"Database connection '{name}' successfully reset."
+            # read connection
+            result["raw"] = read_connection(db_conn, name)
+    elif state == "absent":
+        # state == 'absent' delete the connection if it exists
+        if existing:
+            changed = True
+            result["msg"] = f"Would have deleted the database connection '{name}' if not in check mode."
+            if not module.check_mode:
+                db_conn.delete_connection(name)
+                result["msg"] = f"Database connection '{name}' successfully deleted."
+
+    return changed, result
+
+
+def main():
+
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            state=dict(choices=["present", "absent", "reset"], default="present"),
+            database_mount_path=dict(default="database", aliases=["vault_database_mount_path"]),
+            name=dict(required=True, aliases=["connection_name"]),
+            username=dict(aliases=["connection_username"]),
+            password=dict(aliases=["connection_password"], no_log=True),
+            disable_escaping=dict(type="bool", default=False),
+            connection_url=dict(no_log=True),  # since it can contains password information
+            plugin_name=dict(required=False),
+            plugin_version=dict(),
+            plugin_options=dict(type="dict"),
+            verify_connection=dict(type="bool", default=True),
+            allowed_roles=dict(
+                type="list",
+                elements="str",
+            ),
+            root_rotation_statements=dict(type="list", elements="str"),
+            password_policy=dict(no_log=False),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=(("state", "present", ["plugin_name"]),),
+        supports_check_mode=True,
+    )
+
+    try:
+        changed, result = perform_action(module=module)
+        module.exit_json(changed=changed, **result)
+
+    except VaultSecretNotFoundError as e:
+        module.exit_json(data={})
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/database_connection_info.py
+++ b/plugins/modules/database_connection_info.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: database_connection_info
+short_description: List available connections or read configuration for a specific connection.
+version_added: 1.2.0
+author: Aubin Bikouo (@abikouo)
+description:
+  - This module retrieves configuration details for a specific Vault database connection.
+  - When a connection name is provided, it returns its full settings; if the name is omitted,
+    the module returns a comprehensive list of all available database connections within the specified mount path.
+options:
+  name:
+    description: The name of the database connection to read.
+    required: false
+    type: str
+  database_mount_path:
+    description: Database secret engine mount path.
+    type: str
+    default: database
+    aliases: [vault_database_mount_path]
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+"""
+
+EXAMPLES = """
+- name: Read database connection mysql
+  hashicorp.vault.database_connection_info:
+    name: mysql
+
+- name: List available database connections
+  hashicorp.vault.database_connection_info:
+"""
+
+RETURN = """
+connections:
+  description: The list of database connections.
+  returned: always
+  type: list
+  sample:
+    [
+        {
+            "name": "my-sample-connection",
+            "allowed_roles": ["readonly"],
+            "connection_details": {
+                "connection_url": "dbuser:dbpassword123@tcp(127.0.0.1:3306)/",
+                "username": "vaultuser"
+            },
+            "password_policy": "",
+            "plugin_name": "mysql-database-plugin",
+            "plugin_version": "",
+            "root_credentials_rotate_statements": [],
+            "skip_static_role_import_rotation": false
+        }
+    ]
+"""
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+    VaultDatabaseConnection,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def main():
+
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            name=dict(required=False),
+            database_mount_path=dict(default="database", aliases=["vault_database_mount_path"]),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    # Get authenticated client
+    client = get_authenticated_client(module)
+    mount_path = module.params.get("database_mount_path")
+    name = module.params.get("name")
+
+    try:
+        db_conn = VaultDatabaseConnection(client, mount_path=mount_path)
+        if name:
+            data = db_conn.read_connection(name=name)
+            data.update({"name": name})
+            connections = [data]
+        else:
+            connections = [{"name": name} for name in db_conn.list_connections() or []]
+        module.exit_json(connections=connections)
+
+    except VaultSecretNotFoundError as e:
+        module.exit_json(connections=[])
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/database_connection/aliases
+++ b/tests/integration/targets/database_connection/aliases
@@ -1,0 +1,1 @@
+database_connection_info

--- a/tests/integration/targets/database_connection/defaults/main.yml
+++ b/tests/integration/targets/database_connection/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+vault_approle_path: "approle-integration-tests"
+vault_database_mount_path: "database-conn-config-integration-tests"

--- a/tests/integration/targets/database_connection/meta/main.yml
+++ b/tests/integration/targets/database_connection/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_auth_token

--- a/tests/integration/targets/database_connection/tasks/main.yml
+++ b/tests/integration/targets/database_connection/tasks/main.yml
@@ -1,0 +1,305 @@
+---
+- name: Run database_connection tests
+  module_defaults:
+    group/hashicorp.vault.vault:
+      url: "{{ vault_url }}"
+      namespace: "{{ vault_namespace }}"
+      auth_method: "token"
+      token: "{{ vault_token_from_setup_auth_token }}"
+      vault_approle_path: "{{ vault_approle_path }}"
+      database_mount_path: "{{ vault_database_mount_path }}"
+  vars:
+    mysql_connection_url: "mysql://ansible:secret123@localhost:3306/mydb"
+    mysql_username: "ansible"
+    mysql_password: "secret123"
+    mysql_dbconnection_name: "mysql-{{ vault_resource_suffix }}"
+    mysql_plugin_name: "mysql-database-plugin"
+    mysql_allowed_roles: "readonly"
+  block:
+    # Create database connection
+    - name: Trying to create without required parameters
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+      ignore_errors: true
+      register: create_missing_params
+
+    - name: Ensure task failed
+      ansible.builtin.assert:
+        that:
+          - create_missing_params is failed
+          - 'create_missing_params.msg == "state is present but all of the following are missing: plugin_name"'
+
+    - name: Create database connection (check mode)
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ mysql_plugin_name }}"
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+      check_mode: true
+      register: create_check_mode
+
+    - name: Read existing database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change while the connection was not created
+      ansible.builtin.assert:
+        that:
+          - create_check_mode is changed
+          - db_connection.connections == []
+
+    - name: Create database connection
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ mysql_plugin_name }}"
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+      register: create_conn
+
+    - name: Read existing database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: List database connection
+      hashicorp.vault.database_connection_info:
+      register: db_connection_list
+
+    - name: Validate that module reported change and the connection was created
+      ansible.builtin.assert:
+        that:
+          - create_conn is changed
+          - db_connection.connections[0] | dict2items | rejectattr('key', 'equalto', 'name') | list | items2dict == create_conn.raw
+          - db_connection_list.connections | selectattr('name', 'equalto', mysql_dbconnection_name) | list | length == 1
+
+    - name: Create database connection (idempotency)
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ mysql_plugin_name }}"
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+      register: create_idempotency
+
+    - name: Read existing database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module is idempotent for creation
+      ansible.builtin.assert:
+        that:
+          - create_idempotency is not changed
+          - create_idempotency.raw == create_conn.raw
+
+    # Update database connection
+    - name: Update database connection (check mode)
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ mysql_plugin_name }}"
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+        plugin_options:
+          tls_skip_verify: true
+      check_mode: true
+      register: update_check_mode
+
+    - name: Read database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change while the connection was not updated
+      ansible.builtin.assert:
+        that:
+          - update_check_mode is changed
+          - db_connection.connections[0] | dict2items | rejectattr('key', 'equalto', 'name') | list | items2dict == create_conn.raw
+
+    - name: Update database connection
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ mysql_plugin_name }}"
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+        plugin_options:
+          tls_skip_verify: true
+      register: update_conn
+
+    - name: Read the database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change and the connection was updated
+      ansible.builtin.assert:
+        that:
+          - update_conn is changed
+          - db_connection.connections[0] | dict2items | rejectattr('key', 'equalto', 'name') | list | items2dict == update_conn.raw
+
+    - name: Update database connection (idempotency)
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        connection_url: "{{ mysql_connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ mysql_plugin_name }}"
+        allowed_roles: "{{ mysql_allowed_roles }}"
+        username: "{{ mysql_username }}"
+        password: "{{ mysql_password }}"
+        plugin_options:
+          tls_skip_verify: true
+      register: update_idempotency
+
+    - name: Read existing database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module is idempotent for update
+      ansible.builtin.assert:
+        that:
+          - update_idempotency is not changed
+          - db_connection.connections[0] | dict2items | rejectattr('key', 'equalto', 'name') | list | items2dict == update_conn.raw
+
+    # Reset database connection
+    - name: Reset the database connection (check mode)
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: reset
+      check_mode: true
+      register: reset_check_mode
+
+    - name: Read the database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change while the connection was not reset
+      ansible.builtin.assert:
+        that:
+          - reset_check_mode is changed
+          - db_connection.connections[0] | dict2items | rejectattr('key', 'equalto', 'name') | list | items2dict == update_conn.raw
+
+    - name: Reset the database connection
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: reset
+      register: reset_conn
+
+    - name: Read the database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change and the connection was reset
+      ansible.builtin.assert:
+        that:
+          - reset_conn is changed
+          - db_connection.connections[0] | dict2items | rejectattr('key', 'equalto', 'name') | list | items2dict == update_conn.raw
+
+    - name: Reset the database connection once again
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: reset
+      register: reset_again
+
+    - name: Validate that module is not idempotent for reset
+      ansible.builtin.assert:
+        that:
+          - reset_again is changed
+
+    - name: Reset unexisting database connection
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}-fake"
+        state: reset
+      check_mode: true
+      register: reset_unexisting_check_mode
+
+    - name: Ensure module did not report change
+      ansible.builtin.assert:
+        that:
+          - reset_unexisting_check_mode is not changed
+
+    - name: Reset unexisting database connection
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}-fake"
+        state: reset
+      register: reset_unexisting
+
+    - name: Ensure module did not reported change
+      ansible.builtin.assert:
+        that:
+          - reset_unexisting is not changed
+
+    # Delete database connection
+    - name: Delete the database connection (check mode)
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: absent
+      check_mode: true
+      register: delete_check_mode
+
+    - name: Read the database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change while the connection was not deleted
+      ansible.builtin.assert:
+        that:
+          - delete_check_mode is changed
+          - db_connection.connections | length == 1
+
+    - name: Delete the database connection
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: absent
+      register: delete_conn
+
+    - name: Read the database connection
+      hashicorp.vault.database_connection_info:
+        name: "{{ mysql_dbconnection_name }}"
+      register: db_connection
+
+    - name: Validate that module reported change and the connection was deleted
+      ansible.builtin.assert:
+        that:
+          - delete_conn is changed
+          - db_connection.connections == []
+
+    - name: Delete the database connection once again
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: absent
+      register: delete_idempotent
+
+    - name: Validate module idemopotency for deletion
+      ansible.builtin.assert:
+        that:
+          - delete_idempotent is not changed
+
+  always:
+    - name: Delete the database connection once again
+      hashicorp.vault.database_connection:
+        name: "{{ mysql_dbconnection_name }}"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
## Summary
Backport of PR #50 to stable-1

This adds modules for database connection management:
- `database_connection` - Manage HashiCorp Vault database connections
- `database_connection_info` - Read HashiCorp Vault database connection information

Clean cherry-pick with no conflicts (after stable-1 was updated with merged PRs).

## Test plan
- [x] Clean cherry-pick from main
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)