### PR TITLE
[Backport][Main] Add 1.1.1 release changelog from stable-1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,19 @@ Hashicorp.Vault Release Notes
 
 .. contents:: Topics
 
+v1.1.1
+======
+
+Release Summary
+---------------
+
+This release fixes a bug in the ``kv2_secret_get`` lookup plugin's authentication parameters names so parameters must be passed by correct names.
+
+Bugfixes
+--------
+
+- Fix parameter names used by authentication methods so parameters must be passed by correct names. See https://github.com/ansible-collections/hashicorp.vault/pull/35 for more details.
+
 v1.1.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -44,3 +44,15 @@ releases:
           name: kv1_secret_get
           namespace: null
     release_date: "2025-11-13"
+  1.1.1:
+    changes:
+      bugfixes:
+        - Fix parameter names used by authentication methods so parameters must be passed
+          by correct names. See https://github.com/ansible-collections/hashicorp.vault/pull/35
+          for more details.
+      release_summary: This release fixes a bug in the ``kv2_secret_get`` lookup plugin's
+        authentication parameters names so parameters must be passed by correct names.
+    fragments:
+      - 20260311-fix-auth-param-names.yaml
+      - v1.1.1.yml
+    release_date: "2026-03-13"

--- a/changelogs/fragments/20260311-fix-auth-param-names.yaml
+++ b/changelogs/fragments/20260311-fix-auth-param-names.yaml
@@ -1,4 +1,0 @@
----
-bugfixes:
-  - Fix parameter names used by authentication methods so parameters must be passed by correct names.
-    See https://github.com/ansible-collections/hashicorp.vault/pull/35 for more details.


### PR DESCRIPTION
## Summary
Backport of the 1.1.1 release changelog from stable-1 to main.

The 1.1.1 release was a bugfix release that only went to stable-1 (after main had already moved to 2.0.0-dev). However, main should have a complete historical record of all releases.

This PR adds the 1.1.1 changelog entries to main while keeping the version at `2.0.0-dev`.

## Changes
- Added 1.1.1 section to CHANGELOG.rst
- Added 1.1.1 release to changelogs/changelog.yaml
- Removed changelog fragment that was consumed by the release
- **Did NOT change** galaxy.yml version (remains `2.0.0-dev`)

## Test plan
- [x] Cherry-picked from stable-1 with conflicts resolved
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)