### PR TITLE
[Backport][Stable-1] Upgrade black to 26.3.1 (#64)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
         args: ["--filter-files"]
 
   - repo: https://github.com/psf/black
-    rev: 26.3.0
+    rev: 26.3.1
     hooks:
       - id: black
 

--- a/requirements-linters.txt
+++ b/requirements-linters.txt
@@ -1,3 +1,3 @@
-black==26.3.0
+black==26.3.1
 flake8==7.0.0
 isort==6.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     isort --check {posargs:plugins/ tests/}
 
 [testenv:black]
-deps = black==26.3.0
+deps = black==26.3.1
 skip_install = true
 commands = black {posargs:plugins/ tests/}
 


### PR DESCRIPTION
## Summary
Backport of PR #64 to stable-1

This upgrades black to version 26.3.1 in linter configurations.

Clean cherry-pick with no conflicts.

## Test plan
- [x] Clean cherry-pick from main
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)