### PR TITLE
[Backport][Stable-1] Handle error when there are no database connections (#66)

### DIFF
--- a/changelogs/fragments/66-database-connection-404-handling.yaml
+++ b/changelogs/fragments/66-database-connection-404-handling.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - module_utils/vault_client.py - ``VaultDatabaseConnection.list_connections()`` now returns an empty list
+    instead of raising ``VaultSecretNotFoundError`` when no database connections are configured
+    (https://github.com/ansible-collections/hashicorp.vault/pull/66).

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -174,14 +174,16 @@ class VaultDatabaseConnection:
         List all available connections.
 
         Returns:
-            List[str]: A list of connection names.
+            List[str]: A list of connection names. Returns empty list if no connections exist.
         """
         path = f"v1/{self._mount_path}/config"
-        response_data = self._client._make_request("LIST", path)
-
-        connections = response_data.get("data", {}).get("keys", [])
-
-        return connections
+        try:
+            response_data = self._client._make_request("LIST", path)
+            connections = response_data.get("data", {}).get("keys", [])
+            return connections
+        except VaultSecretNotFoundError:
+            # Vault returns 404 when no connections exist
+            return []
 
     def read_connection(self, name: str) -> dict:
         """
@@ -192,10 +194,12 @@ class VaultDatabaseConnection:
 
         Returns:
             dict: The connection configuration data.
+
+        Raises:
+            VaultSecretNotFoundError: If the connection doesn't exist.
         """
         path = f"v1/{self._mount_path}/config/{name}"
         response_data = self._client._make_request("GET", path)
-
         return response_data.get("data", {})
 
     def create_or_update_connection(self, name: str, config: dict) -> dict:

--- a/tests/unit/plugins/module_utils/test_vault_database_connection.py
+++ b/tests/unit/plugins/module_utils/test_vault_database_connection.py
@@ -128,6 +128,12 @@ class TestDatabaseListConnections:
         authenticated_client._make_request.assert_called_once_with("LIST", expected_path)
         assert db_names == mock_list_connections_response["data"]["keys"]
 
+    def test_list_connections_not_found(self, authenticated_client):
+        authenticated_client._make_request.side_effect = VaultSecretNotFoundError("not found")
+        db_conn = VaultDatabaseConnection(client=authenticated_client)
+        result = db_conn.list_connections()
+        assert result == []
+
     def test_list_connections_error(self, authenticated_client):
         authenticated_client._make_request.side_effect = VaultPermissionError("permission denied")
         db_conn = VaultDatabaseConnection(client=authenticated_client)


### PR DESCRIPTION
## Summary
Backport of PR #66 to stable-1

This improves error handling when there are no database connections configured in Vault.

Clean cherry-pick with no conflicts.

## Test plan
- [x] Clean cherry-pick from main
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)