### PR TITLE
Database static role modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # integration tests configuration file
 tests/integration/integration_config.yml
+
 # https://raw.githubusercontent.com/github/gitignore/main/Python.gitignore
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -84,7 +85,7 @@ target/
 # IPython
 profile_default/
 ipython_config.py
-tests/integration/integration_config.yml
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:
@@ -161,6 +162,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# VS Code
+.vscode/
 
 # MacOS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -32,10 +32,22 @@ Name | Description
 ### Modules
 Name | Description
 --- | ---
-[hashicorp.vault.kv2_secret](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret.py)|Manage HashiCorp Vault KV version 2 secrets
-[hashicorp.vault.kv2_secret_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret_info.py)|Read HashiCorp Vault KV version 2 secrets
 [hashicorp.vault.acl_policy](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/acl_policy.py)|Manage HashiCorp Vault ACL policies
 [hashicorp.vault.acl_policy_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/acl_policy_info.py)|List and read HashiCorp Vault ACL policies
+[hashicorp.vault.auth_login](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/auth_login.py)|Authenticate to HashiCorp Vault
+[hashicorp.vault.auth_token](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/auth_token.py)|Manage HashiCorp Vault tokens
+[hashicorp.vault.auth_token_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/auth_token_info.py)|Retrieve information about a specific HashiCorp Vault token
+[hashicorp.vault.database_connection](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/database_connection.py)|Manage database secrets engine connections in HashiCorp Vault
+[hashicorp.vault.database_connection_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/database_connection_info.py)|List available connections or read configuration for a specific connection
+[hashicorp.vault.database_static_role](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/database_static_role.py)|Manage database static roles in HashiCorp Vault
+[hashicorp.vault.database_static_role_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/database_static_role_info.py)|List available static roles or read the configuration for a specific static role
+[hashicorp.vault.kv1_secret](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv1_secret.py)|Manage HashiCorp Vault KV version 1 secrets
+[hashicorp.vault.kv1_secret_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv1_secret_info.py)|Read HashiCorp Vault KV version 1 secrets
+[hashicorp.vault.kv2_secret](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret.py)|Manage HashiCorp Vault KV version 2 secrets
+[hashicorp.vault.kv2_secret_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/kv2_secret_info.py)|Read HashiCorp Vault KV version 2 secrets
+[hashicorp.vault.pki_certificate](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/pki_certificate.py)|Issue, sign, or revoke HashiCorp Vault PKI certificates
+[hashicorp.vault.pki_certificate_info](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/pki_certificate_info.py)|List and read HashiCorp Vault PKI certificates
+[hashicorp.vault.vault_namespace](https://github.com/ansible-collections/hashicorp.vault/blob/main/plugins/modules/vault_namespace.py)|Manage HashiCorp Vault Enterprise namespaces
 
 ## Installation
 
@@ -86,7 +98,12 @@ See [Ansible Using Collections](https://docs.ansible.com/ansible/latest/user_gui
 
 Modules in this collection can be used for various operations on HashiCorp Vault.
 Currently the collection supports:
-- Managing KV2 secrets in HashiCorp Vault (create, read, update, delete [soft-delete])
+- Managing KV1 and KV2 secrets in HashiCorp Vault (create, read, update, delete)
+- Managing ACL policies in HashiCorp Vault
+- Authentication and token management
+- Managing database secrets engine connections and static roles
+- Managing PKI certificates (issue, sign, revoke, read)
+- Managing Vault Enterprise namespaces
 
 ## Testing
 

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -12,6 +12,8 @@ action_groups:
     - database_role
     - database_role_info
     - database_credential_rotation
+    - database_static_role
+    - database_static_role_info
     - kv1_secret
     - kv1_secret_info
     - kv2_secret

--- a/plugins/module_utils/vault_database.py
+++ b/plugins/module_utils/vault_database.py
@@ -671,6 +671,26 @@ class Database:
         self.dynamic_roles = VaultDatabaseDynamicRoles(client, mount_path)
 
 
+def get_static_role(static_role_client: "VaultDatabaseStaticRoles", name: str) -> Dict[str, Any]:
+    """
+    Get a database static role configuration, returning an empty dict if not found.
+
+    This is a utility function to avoid repetitive try/except blocks when
+    reading static roles where a "not found" condition is acceptable.
+
+    Args:
+        static_role_client: VaultDatabaseStaticRoles instance
+        name: The name of the static role to read
+
+    Returns:
+        dict: The static role configuration, or {} if not found
+    """
+    try:
+        return static_role_client.read_static_role(name)
+    except VaultSecretNotFoundError:
+        return {}
+
+
 __all__ = [
     'VaultDatabaseParent',
     'Database',
@@ -679,6 +699,7 @@ __all__ = [
     'VaultDatabaseDynamicRoles',
     'build_config_params',
     'get_existing_role_or_none',
+    'get_static_role',
     'normalize_value',
     'compare_vault_configs',
 ]

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -8,14 +8,13 @@ from __future__ import absolute_import, division, print_function
 DOCUMENTATION = """
 ---
 module: database_static_role
-short_description: Manage database static roles in HashiCorp Vault.
+short_description: Manage database static roles in HashiCorp Vault
 version_added: 1.2.0
 author: Hannah DeFazio (@hdefazio)
 description:
   - This module allows you to create, update, and delete database static roles in HashiCorp Vault.
-  - Static roles provide a mechanism to use Vault as a credential broker for existing database accounts.
-  - Use C(state=present) to create or update a static role.
-  - Use C(state=absent) to delete a static role.
+  - Use O(state=present) to create or update a static role.
+  - Use O(state=absent) to delete a static role.
 options:
   state:
     description:
@@ -57,7 +56,10 @@ options:
       - Specifies the amount of time Vault should wait before rotating the password.
       - The minimum rotation period is 5 seconds.
       - Can be specified as an integer (seconds) or a duration string (e.g., "86400s", "24h").
+      - Duration strings are normalized to integer seconds before being sent to Vault.
+      - See U(https://developer.hashicorp.com/vault/docs/concepts/duration-format) for duration format details.
       - Required when O(state=present) unless O(rotation_schedule) is provided.
+      - Mutually exclusive with O(rotation_schedule).
     type: raw
   rotation_schedule:
     description:
@@ -72,6 +74,8 @@ options:
       - If the credential is not rotated during this window, it will not be rotated until the next scheduled rotation.
       - The minimum is 1 hour.
       - Can be specified as an integer (seconds) or a duration string (e.g., "3600s", "1h").
+      - Duration strings are normalized to integer seconds before being sent to Vault.
+      - See U(https://developer.hashicorp.com/vault/docs/concepts/duration-format) for duration format details.
       - Optional when O(rotation_schedule) is set and disallowed when O(rotation_period) is set.
     type: raw
   rotation_statements:
@@ -92,7 +96,6 @@ options:
   credential_type:
     description:
       - Specifies the type of credential that will be generated for the role.
-      - See the plugin's API documentation for credential types supported by individual databases.
     type: str
     default: password
     choices: [password, rsa_private_key, client_certificate]
@@ -158,7 +161,7 @@ msg:
   sample: "Static role 'my-static-role' created successfully"
 raw:
   description: The configuration settings for the database static role created/updated.
-  returned: when I(state=present)
+  returned: when O(state=present)
   type: dict
   sample:
     {
@@ -173,6 +176,7 @@ raw:
 __metaclass__ = type  # pylint: disable=C0103
 
 import copy
+import re
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
 
@@ -180,8 +184,11 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
     get_authenticated_client,
 )
-from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_database import (
     VaultDatabaseStaticRoles,
+    compare_vault_configs,
+    get_static_role,
+    build_config_params,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
     VaultApiError,
@@ -190,21 +197,165 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
 )
 
 
+def _validate_duration_format(value, param_name):
+    """
+    Validate that a duration parameter is in a valid format.
+
+    Vault accepts durations as either:
+    - An integer (interpreted as seconds)
+    - A string with a valid duration suffix (e.g., "72h", "24h", "5m", "30s")
+
+    Valid duration units: ns, us/µs, ms, s, m, h
+
+    See: https://developer.hashicorp.com/vault/docs/concepts/duration-format
+
+    Args:
+        value: The value to validate
+        param_name: The name of the parameter (for error messages)
+
+    Raises:
+        ValueError: If the value is not a valid duration format
+
+    Examples:
+        _validate_duration_format(86400, "rotation_period")  # Valid: int
+        _validate_duration_format("24h", "rotation_period")  # Valid: duration string
+        _validate_duration_format("invalid", "rotation_period")  # Raises ValueError
+        _validate_duration_format([1, 2], "rotation_period")  # Raises ValueError
+    """
+    # Reject booleans explicitly (bool is a subclass of int in Python)
+    if isinstance(value, bool):
+        raise ValueError(
+            f"{param_name} must be an integer (seconds) or a duration string (e.g., '72h', '5m', '30s'). "
+            f"Got type bool: {value!r}"
+        )
+
+    # Check if it's a positive integer
+    if isinstance(value, int):
+        if value <= 0:
+            raise ValueError(
+                f"{param_name} must be a positive integer or a valid duration string. " f"Got integer value: {value}"
+            )
+        return
+
+    # Check if it's a string with valid duration format
+    if isinstance(value, str):
+        # Vault duration format: optional negative sign, number, and unit suffix
+        # Valid units: ns, us (or µs), ms, s, m, h
+        duration_pattern = r'^-?(\d+(\.\d+)?)(ns|us|µs|ms|s|m|h)$'
+        if not re.match(duration_pattern, value):
+            raise ValueError(
+                f"{param_name} must be a valid duration string (e.g., '72h', '5m', '30s') or an integer (seconds). "
+                f"Valid units are: ns, us/µs, ms, s, m, h. Got: {value!r}"
+            )
+        return
+
+    # If it's neither int nor string, raise an error
+    raise ValueError(
+        f"{param_name} must be an integer (seconds) or a duration string (e.g., '72h', '5m', '30s'). "
+        f"Got type {type(value).__name__}: {value!r}"
+    )
+
+
+def _normalize_duration_to_seconds(value):
+    """
+    Convert a duration value to integer seconds for comparison with Vault's normalized format.
+
+    Vault stores durations as integers (seconds), but accepts string formats like "24h" or "86400s".
+    This function normalizes user input to match Vault's storage format.
+
+    Args:
+        value: Duration as integer (seconds) or string with unit suffix
+
+    Returns:
+        int: Duration in seconds
+
+    Raises:
+        TypeError: If value is not an int or str
+
+    Examples:
+        _normalize_duration_to_seconds(86400) → 86400
+        _normalize_duration_to_seconds("24h") → 86400
+        _normalize_duration_to_seconds("86400s") → 86400
+        _normalize_duration_to_seconds("1.5h") → 5400
+    """
+    if isinstance(value, int):
+        return value
+
+    if isinstance(value, str):
+        # Parse duration string: number + unit
+        duration_pattern = r'^-?(\d+(?:\.\d+)?)(ns|us|µs|ms|s|m|h)$'
+        match = re.match(duration_pattern, value)
+        if not match:
+            # Should not happen if validation ran first, but fail fast if it does
+            raise TypeError(f"Invalid duration format: {value!r} (validation should have caught this)")
+
+        number_str, unit = match.groups()
+        number = float(number_str)
+
+        # Convert to seconds based on unit
+        unit_to_seconds = {
+            'ns': 1e-9,
+            'us': 1e-6,
+            'µs': 1e-6,
+            'ms': 1e-3,
+            's': 1,
+            'm': 60,
+            'h': 3600,
+        }
+
+        seconds = number * unit_to_seconds[unit]
+        # Vault stores as integer seconds, round to avoid sub-second values becoming 0
+        return int(round(seconds))
+
+    # If not int or string, this is a programming error
+    raise TypeError(f"Duration must be int or str, got {type(value).__name__}: {value!r}")
+
+
+def _validate_rotation_params(module):
+    """
+    Validate rotation-related parameters for database static roles.
+
+    Ensures:
+    - At least one of rotation_period or rotation_schedule is provided
+    - Duration formats are valid
+
+    Note: Mutual exclusivity and required_by constraints are handled by
+    AnsibleModule's built-in validation (mutually_exclusive, required_by).
+
+    Args:
+        module: AnsibleModule instance
+
+    Raises:
+        Calls module.fail_json() if validation fails
+    """
+    rotation_period = module.params.get("rotation_period")
+    rotation_schedule = module.params.get("rotation_schedule")
+    rotation_window = module.params.get("rotation_window")
+
+    # At least one of rotation_period or rotation_schedule is required
+    if not rotation_period and not rotation_schedule:
+        module.fail_json(
+            msg=(
+                "One of rotation_period or rotation_schedule is required when state=present. "
+                f"Got rotation_period={rotation_period}, rotation_schedule={rotation_schedule}"
+            )
+        )
+
+    # Validate duration formats
+    try:
+        if rotation_period is not None:
+            _validate_duration_format(rotation_period, "rotation_period")
+        if rotation_window is not None:
+            _validate_duration_format(rotation_window, "rotation_window")
+    except ValueError as e:
+        module.fail_json(msg=str(e))
+
+
 def ensure_present(module: AnsibleModule, db_static_role_client: VaultDatabaseStaticRoles) -> None:
     """Create or update a database static role."""
     name = module.params.get("name")
 
-    # Validate that at least one of rotation_period or rotation_schedule is provided
-    if not module.params.get("rotation_period") and not module.params.get("rotation_schedule"):
-        module.fail_json(msg="one of rotation_period or rotation_schedule is required when state=present")
-
-    # Validate that both are not provided (mutual exclusivity)
-    if module.params.get("rotation_period") and module.params.get("rotation_schedule"):
-        module.fail_json(msg="rotation_period and rotation_schedule are mutually exclusive")
-
-    # Validate that rotation_window is only used with rotation_schedule
-    if module.params.get("rotation_window") and module.params.get("rotation_period"):
-        module.fail_json(msg="rotation_window can only be used with rotation_schedule, not rotation_period")
+    _validate_rotation_params(module)
 
     # Build configuration from module parameters, filtering out None values
     config_params = (
@@ -219,37 +370,45 @@ def ensure_present(module: AnsibleModule, db_static_role_client: VaultDatabaseSt
         "credential_type",
         "credential_config",
     )
-    config = {key: val for key in config_params if (val := module.params.get(key)) is not None}
+    config = build_config_params(module.params, config_params)
 
-    # Check if the static role already exists
-    # VaultSecretNotFoundError is raised if the role doesn't exist
-    try:
-        existing = db_static_role_client.read_static_role(name)
-    except VaultSecretNotFoundError:
-        existing = {}
+    # Normalize duration fields in config to match Vault's format (integer seconds)
+    # This allows accurate comparison and avoids false positives like "24h" != 86400
+    if 'rotation_period' in config:
+        config['rotation_period'] = _normalize_duration_to_seconds(config['rotation_period'])
+    if 'rotation_window' in config:
+        config['rotation_window'] = _normalize_duration_to_seconds(config['rotation_window'])
 
+    # Read existing role configuration from Vault for comparison
+    existing = get_static_role(db_static_role_client, name)
+
+    # Determine if update is needed by comparing normalized config with existing state
+    needs_update = not compare_vault_configs(existing, config)
+
+    # If role exists with matching config, exit early
+    if existing and not needs_update:
+        module.exit_json(
+            changed=False, msg=f"Database static role {name!r} already exists with the same data.", raw=existing
+        )
+
+    # Determine operation type for messaging
     operation = "updated" if existing else "created"
 
     # In check mode, report what would happen without making changes
     if module.check_mode:
         module.exit_json(
-            changed=True, msg=f"Would have {operation} database static role '{name}' if not in check mode", raw=existing
+            changed=True,
+            msg=f"Would have {operation} database static role '{name}' if not in check mode",
+            raw=existing or {},
         )
 
     # Create or update the static role
     db_static_role_client.create_or_update_static_role(name, config)
 
-    # Read back the configuration to compare for idempotency
+    # Read back the result
     result = db_static_role_client.read_static_role(name)
 
-    # Check idempotency - compare the new result with what existed before
-    changed = not (result == existing)
-    if not changed:
-        msg = "The database static role already exists with the same data."
-    else:
-        msg = f"Database static role {name!r} {operation} successfully"
-
-    module.exit_json(changed=changed, msg=msg, raw=result)
+    module.exit_json(changed=True, msg=f"Database static role {name!r} {operation} successfully", raw=result)
 
 
 def ensure_absent(module: AnsibleModule, db_static_role_client: VaultDatabaseStaticRoles) -> None:
@@ -257,10 +416,8 @@ def ensure_absent(module: AnsibleModule, db_static_role_client: VaultDatabaseSta
     name = module.params.get("name")
 
     # Check if the static role exists before attempting deletion
-    # VaultSecretNotFoundError is raised if the role doesn't exist
-    try:
-        db_static_role_client.read_static_role(name)
-    except VaultSecretNotFoundError:
+    existing = get_static_role(db_static_role_client, name)
+    if not existing:
         module.exit_json(
             changed=False,
             msg=f"Database static role {name!r} is already absent",
@@ -273,8 +430,17 @@ def ensure_absent(module: AnsibleModule, db_static_role_client: VaultDatabaseSta
             msg=f"Would have deleted database static role {name!r} if not in check mode.",
         )
 
-    # Actually delete the static role
-    db_static_role_client.delete_static_role(name)
+    # Actually delete the static role (404 if removed between read and delete)
+    try:
+        db_static_role_client.delete_static_role(name)
+    except VaultSecretNotFoundError:
+        module.exit_json(
+            changed=False,
+            msg=(
+                f"Database static role {name!r} was present when read but Vault returned "
+                "'not found' on delete (likely removed concurrently); treating as absent."
+            ),
+        )
     module.exit_json(
         changed=True,
         msg=f"Database static role {name!r} deleted successfully",
@@ -306,23 +472,26 @@ def main() -> None:
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_if=(("state", "present", ["db_name", "username"]),),
+        mutually_exclusive=[
+            ["rotation_period", "rotation_schedule"],
+            ["rotation_period", "rotation_window"],
+        ],
+        required_by={"rotation_window": "rotation_schedule"},
         supports_check_mode=True,
     )
 
     client = get_authenticated_client(module)
 
-    mount_path = module.params["database_mount_path"]
-    db_static_role_client = VaultDatabaseStaticRoles(client, mount_path=mount_path)
+    mount_path = module.params.get("database_mount_path")
+    state = module.params.get("state")
 
-    state = module.params["state"]
     try:
+        db_static_role_client = VaultDatabaseStaticRoles(client, mount_path=mount_path)
+
         if state == "present":
             ensure_present(module, db_static_role_client)
         elif state == "absent":
             ensure_absent(module, db_static_role_client)
-
-    except VaultSecretNotFoundError as e:
-        module.exit_json(data={})
     except VaultPermissionError as e:
         module.fail_json(msg=f"Permission denied: {e}")
     except VaultApiError as e:

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -47,6 +47,12 @@ options:
       - This must be an existing user in the database.
       - Required when O(state=present).
     type: str
+  password:
+    description:
+      - The password corresponding to the username in the database.
+      - Required when using the Rootless Password Rotation workflow or Skip Automatic Import Rotation workflow for static roles.
+      - Only available in Vault Enterprise.
+    type: str
   rotation_period:
     description:
       - Specifies the amount of time Vault should wait before rotating the password.
@@ -57,12 +63,23 @@ options:
   rotation_schedule:
     description:
       - A cron-style schedule for password rotation (e.g., "0 0 * * *" for daily at midnight).
+      - Vault interprets the schedule in UTC.
       - Required when O(state=present) unless O(rotation_period) is provided.
+      - Mutually exclusive with O(rotation_period).
     type: str
+  rotation_window:
+    description:
+      - Specifies the amount of time in which the rotation is allowed to occur starting from a given O(rotation_schedule).
+      - If the credential is not rotated during this window, it will not be rotated until the next scheduled rotation.
+      - The minimum is 1 hour.
+      - Can be specified as an integer (seconds) or a duration string (e.g., "3600s", "1h").
+      - Optional when O(rotation_schedule) is set and disallowed when O(rotation_period) is set.
+    type: raw
   rotation_statements:
     description:
       - Specifies the database statements to be executed to rotate the password.
       - If not specified, Vault uses the default rotation statements for the database plugin.
+      - Not every plugin type supports this functionality.
     type: list
     elements: str
   skip_import_rotation:
@@ -70,20 +87,42 @@ options:
       - When set to V(true), skips the automatic password rotation that normally occurs when creating a static role.
       - This allows testing configuration without requiring an active database connection.
       - The password will still be rotated on the first scheduled rotation or manual rotation request.
+      - Only available in Vault Enterprise.
     type: bool
     default: false
+  credential_type:
+    description:
+      - Specifies the type of credential that will be generated for the role.
+      - See the plugin's API documentation for credential types supported by individual databases.
+    type: str
+    default: password
+    choices: [password, rsa_private_key, client_certificate]
+  credential_config:
+    description:
+      - Specifies the configuration for the given O(credential_type).
+      - This should be a dictionary of options required by the specific credential type.
+    type: dict
 extends_documentation_fragment:
   - hashicorp.vault.vault_auth.modules
 """
 
 EXAMPLES = """
-- name: Create a database static role
+- name: Create a database static role with rotation period
   hashicorp.vault.database_static_role:
     name: my-static-role
     state: present
     db_name: my-postgres-db
     username: vault-user
-    rotation_period: 86400
+    rotation_period: "24h"
+
+- name: Create a database static role with rotation schedule
+  hashicorp.vault.database_static_role:
+    name: my-static-role
+    state: present
+    db_name: my-postgres-db
+    username: vault-user
+    rotation_schedule: "0 0 * * *"
+    rotation_window: "3h"
 
 - name: Create a database static role with custom rotation statements
   hashicorp.vault.database_static_role:
@@ -91,10 +130,25 @@ EXAMPLES = """
     state: present
     db_name: my-mysql-db
     username: app_user
-    rotation_period: 3600
+    rotation_period: "1h"
     rotation_statements:
       - "ALTER USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';"
-    database_mount_path: database
+
+- name: Create a static role with RSA private key credential type
+  hashicorp.vault.database_static_role:
+    name: my-rsa-role
+    state: present
+    db_name: my-postgres-db
+    username: rsa-user
+    rotation_period: "24h"
+    credential_type: rsa_private_key
+    credential_config:
+      key_bits: 2048
+
+- name: Delete a database static role
+  hashicorp.vault.database_static_role:
+    name: my-static-role
+    state: absent
 """
 
 RETURN = """
@@ -146,7 +200,18 @@ def ensure_present(module: AnsibleModule, db_static_role_client: VaultDatabaseSt
         module.fail_json(msg="one of rotation_period or rotation_schedule is required when state=present")
 
     # Build configuration from module parameters, filtering out None values
-    config_params = ("username", "db_name", "rotation_period", "rotation_schedule", "rotation_statements", "skip_import_rotation")
+    config_params = (
+        "username",
+        "db_name",
+        "password",
+        "rotation_period",
+        "rotation_schedule",
+        "rotation_window",
+        "rotation_statements",
+        "skip_import_rotation",
+        "credential_type",
+        "credential_config",
+    )
     config = {key: val for key in config_params if (val := module.params.get(key)) is not None}
 
     # Check if the static role already exists
@@ -219,10 +284,14 @@ def main() -> None:
             name=dict(required=True),
             db_name=dict(),
             username=dict(),
+            password=dict(no_log=True),
             rotation_period=dict(type="raw"),
             rotation_schedule=dict(type="str"),
+            rotation_window=dict(type="raw"),
             rotation_statements=dict(type="list", elements="str"),
             skip_import_rotation=dict(type="bool"),
+            credential_type=dict(type="str", default="password", choices=["password", "rsa_private_key", "client_certificate"]),
+            credential_config=dict(type="dict", no_log=True),
         )
     )
     module = AnsibleModule(

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 DOCUMENTATION = """
 ---
 module: database_static_role
@@ -290,7 +289,9 @@ def main() -> None:
             rotation_window=dict(type="raw"),
             rotation_statements=dict(type="list", elements="str"),
             skip_import_rotation=dict(type="bool"),
-            credential_type=dict(type="str", default="password", choices=["password", "rsa_private_key", "client_certificate"]),
+            credential_type=dict(
+                type="str", default="password", choices=["password", "rsa_private_key", "client_certificate"]
+            ),
             credential_config=dict(type="dict", no_log=True),
         )
     )

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+DOCUMENTATION = """
+    module: database_static_role
+    author: Hannah DeFazio (@hdefazio)
+    version_added: "1.2.0"
+    short_description: Manage database static roles in HashiCorp Vault.
+    description:
+      - This module allows you to create, update, and delete database static roles in HashiCorp Vault.
+      - Static roles provide a mechanism to use Vault as a credential broker for existing database accounts.
+      - Use C(state=present) to create or update a static role.
+      - Use C(state=absent) to delete a static role.
+    options:
+      name:
+        description: The name of the database static role.
+        type: str
+        required: true
+      state:
+        description:
+          - Goal state for the database static role.
+          - Use V(present) to create or update the static role.
+          - Use V(absent) to delete the static role.
+        choices: [present, absent]
+        default: present
+        type: str
+      db_name:
+        description:
+          - The name of the database connection to use for this static role.
+          - This references a connection created by the M(hashicorp.vault.database_connection) module.
+          - Required when O(state=present).
+        type: str
+      username:
+        description:
+          - The database username that Vault will manage and rotate credentials for.
+          - This must be an existing user in the database.
+          - Required when O(state=present).
+        type: str
+"""
+
+EXAMPLES = """
+- name: Create a database static role
+  hashicorp.vault.database_static_role:
+    name: my-static-role
+    state: present
+    db_name: my-postgres-db
+    username: vault-user
+    rotation_period: 86400
+
+- name: Create a database static role with custom rotation statements
+  hashicorp.vault.database_static_role:
+    name: my-static-role
+    state: present
+    db_name: my-mysql-db
+    username: app_user
+    rotation_period: 3600
+    rotation_statements:
+      - "ALTER USER '{{name}}'@'%' IDENTIFIED BY '{{password}}';"
+    database_mount_path: database
+"""
+
+RETURN = """
+msg:
+  description: A message describing the result of the operation.
+  returned: always
+  type: str
+  sample: "Static role 'my-static-role' created successfully"
+raw:
+  description: The configuration settings for the database static role created/updated.
+  returned: when I(state=present)
+  type: dict
+  sample:
+    {
+        "db_name": "my-postgres-db",
+        "username": "vault-user",
+        "rotation_period": 86400,
+        "rotation_statements": []
+    }
+"""
+
+
+__metaclass__ = type  # pylint: disable=C0103
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+    VaultClient,
+    VaultDatabaseStaticRoles,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def ensure_present(module: AnsibleModule, client: VaultClient, db_static_roles: VaultDatabaseStaticRoles) -> None:
+    """Create or update a database static role."""
+    name = module.params.get("name")
+
+    # Build configuration from module parameters, filtering out None values
+    config_params = (
+        "username",
+        "db_name"
+    )
+    config = {key: val for key in config_params if (val := module.params.get(key)) is not None}
+
+    # Check if the static role already exists
+    # VaultSecretNotFoundError is raised if the role doesn't exist
+    try:
+        existing = db_static_roles.read_static_role(name)
+    except VaultSecretNotFoundError:
+        existing = {}
+
+    # If role exists and no changes needed, exit early with changed=False
+    needs_update = any(existing.get(k) != v for k, v in config.items())
+    if existing and not needs_update:
+        module.exit_json(
+            changed=False,
+            msg="The database static role already exists with the same data.",
+            raw=existing
+        )
+
+    operation = "updated" if existing else "created"
+
+    # In check mode, report what would happen without making changes
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            msg=f"Would have {operation} database static role '{name}' if not in check mode",
+            raw=existing
+        )
+
+    # Actually create or update the static role
+    db_static_roles.create_or_update_static_role(name, config)
+
+    # Read back the configuration to return to the user
+    result = db_static_roles.read_static_role(name)
+
+    module.exit_json(
+        changed=True,
+        msg=f"Database static role {name!r} {operation} successfully",
+        raw=result
+    )
+
+    
+
+
+def main() -> None:
+    """Entry point for module execution"""
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            name=dict(required=True),
+            state=dict(default="present", choices=["present", "absent"]),
+            database_mount_path=dict(default="database", aliases=["vault_database_mount_path"]),
+            db_name=dict(),
+            username=dict(),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        required_if=(("state", "present", ["db_name", "username"]),),
+        supports_check_mode=True
+    )
+
+    client = get_authenticated_client(module)
+
+    mount_path = module.params["database_mount_path"]
+    db_static_roles = VaultDatabaseStaticRoles(client, mount_path=mount_path)
+
+    state = module.params["state"]
+    try:
+        if state == "present":                                                                                                                
+            ensure_present(module, client, db_static_roles)  
+                                                                                      
+    except VaultSecretNotFoundError as e:
+        module.exit_json(data={})
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -198,6 +198,14 @@ def ensure_present(module: AnsibleModule, db_static_role_client: VaultDatabaseSt
     if not module.params.get("rotation_period") and not module.params.get("rotation_schedule"):
         module.fail_json(msg="one of rotation_period or rotation_schedule is required when state=present")
 
+    # Validate that both are not provided (mutual exclusivity)
+    if module.params.get("rotation_period") and module.params.get("rotation_schedule"):
+        module.fail_json(msg="rotation_period and rotation_schedule are mutually exclusive")
+
+    # Validate that rotation_window is only used with rotation_schedule
+    if module.params.get("rotation_window") and module.params.get("rotation_period"):
+        module.fail_json(msg="rotation_window can only be used with rotation_schedule, not rotation_period")
+
     # Build configuration from module parameters, filtering out None values
     config_params = (
         "username",

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -252,7 +252,7 @@ def _validate_duration_format(value, param_name):
     # If it's neither int nor string, raise an error
     raise ValueError(
         f"{param_name} must be an integer (seconds) or a duration string (e.g., '72h', '5m', '30s'). "
-        f"Got type {type(value).__name__}: {value!r}"
+        f"Got type {value.__class__.__name__}: {value!r}"
     )
 
 
@@ -308,7 +308,7 @@ def _normalize_duration_to_seconds(value):
         return int(round(seconds))
 
     # If not int or string, this is a programming error
-    raise TypeError(f"Duration must be int or str, got {type(value).__name__}: {value!r}")
+    raise TypeError(f"Duration must be int or str, got {value.__class__.__name__}: {value!r}")
 
 
 def _validate_rotation_params(module):

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -7,40 +7,73 @@ from __future__ import absolute_import, division, print_function
 
 
 DOCUMENTATION = """
-    module: database_static_role
-    author: Hannah DeFazio (@hdefazio)
-    version_added: "1.2.0"
-    short_description: Manage database static roles in HashiCorp Vault.
+---
+module: database_static_role
+short_description: Manage database static roles in HashiCorp Vault.
+version_added: 1.2.0
+author: Hannah DeFazio (@hdefazio)
+description:
+  - This module allows you to create, update, and delete database static roles in HashiCorp Vault.
+  - Static roles provide a mechanism to use Vault as a credential broker for existing database accounts.
+  - Use C(state=present) to create or update a static role.
+  - Use C(state=absent) to delete a static role.
+options:
+  state:
     description:
-      - This module allows you to create, update, and delete database static roles in HashiCorp Vault.
-      - Static roles provide a mechanism to use Vault as a credential broker for existing database accounts.
-      - Use C(state=present) to create or update a static role.
-      - Use C(state=absent) to delete a static role.
-    options:
-      name:
-        description: The name of the database static role.
-        type: str
-        required: true
-      state:
-        description:
-          - Goal state for the database static role.
-          - Use V(present) to create or update the static role.
-          - Use V(absent) to delete the static role.
-        choices: [present, absent]
-        default: present
-        type: str
-      db_name:
-        description:
-          - The name of the database connection to use for this static role.
-          - This references a connection created by the M(hashicorp.vault.database_connection) module.
-          - Required when O(state=present).
-        type: str
-      username:
-        description:
-          - The database username that Vault will manage and rotate credentials for.
-          - This must be an existing user in the database.
-          - Required when O(state=present).
-        type: str
+      - Goal state for the database static role.
+      - Use V(present) to create or update the static role.
+      - Use V(absent) to delete the static role.
+    choices: [present, absent]
+    default: present
+    type: str
+  database_mount_path:
+    description: Database secret engine mount path.
+    type: str
+    default: database
+    aliases: [vault_database_mount_path]
+  name:
+    description: The name of the database static role.
+    type: str
+    required: true
+  db_name:
+    description:
+      - The name of the database connection to use for this static role.
+      - This references a connection created by the M(hashicorp.vault.database_connection) module.
+      - Required when O(state=present).
+    type: str
+  username:
+    description:
+      - The database username that Vault will manage and rotate credentials for.
+      - This must be an existing user in the database.
+      - Required when O(state=present).
+    type: str
+  rotation_period:
+    description:
+      - Specifies the amount of time Vault should wait before rotating the password.
+      - The minimum rotation period is 5 seconds.
+      - Can be specified as an integer (seconds) or a duration string (e.g., "86400s", "24h").
+      - Required when O(state=present) unless O(rotation_schedule) is provided.
+    type: raw
+  rotation_schedule:
+    description:
+      - A cron-style schedule for password rotation (e.g., "0 0 * * *" for daily at midnight).
+      - Required when O(state=present) unless O(rotation_period) is provided.
+    type: str
+  rotation_statements:
+    description:
+      - Specifies the database statements to be executed to rotate the password.
+      - If not specified, Vault uses the default rotation statements for the database plugin.
+    type: list
+    elements: str
+  skip_import_rotation:
+    description:
+      - When set to V(true), skips the automatic password rotation that normally occurs when creating a static role.
+      - This allows testing configuration without requiring an active database connection.
+      - The password will still be rotated on the first scheduled rotation or manual rotation request.
+    type: bool
+    default: false
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
 """
 
 EXAMPLES = """
@@ -95,7 +128,6 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils i
     get_authenticated_client,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
-    VaultClient,
     VaultDatabaseStaticRoles,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
@@ -105,56 +137,76 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
 )
 
 
-def ensure_present(module: AnsibleModule, client: VaultClient, db_static_roles: VaultDatabaseStaticRoles) -> None:
+def ensure_present(module: AnsibleModule, db_static_role_client: VaultDatabaseStaticRoles) -> None:
     """Create or update a database static role."""
     name = module.params.get("name")
 
+    # Validate that at least one of rotation_period or rotation_schedule is provided
+    if not module.params.get("rotation_period") and not module.params.get("rotation_schedule"):
+        module.fail_json(msg="one of rotation_period or rotation_schedule is required when state=present")
+
     # Build configuration from module parameters, filtering out None values
-    config_params = (
-        "username",
-        "db_name"
-    )
+    config_params = ("username", "db_name", "rotation_period", "rotation_schedule", "rotation_statements", "skip_import_rotation")
     config = {key: val for key in config_params if (val := module.params.get(key)) is not None}
 
     # Check if the static role already exists
     # VaultSecretNotFoundError is raised if the role doesn't exist
     try:
-        existing = db_static_roles.read_static_role(name)
+        existing = db_static_role_client.read_static_role(name)
     except VaultSecretNotFoundError:
         existing = {}
-
-    # If role exists and no changes needed, exit early with changed=False
-    needs_update = any(existing.get(k) != v for k, v in config.items())
-    if existing and not needs_update:
-        module.exit_json(
-            changed=False,
-            msg="The database static role already exists with the same data.",
-            raw=existing
-        )
 
     operation = "updated" if existing else "created"
 
     # In check mode, report what would happen without making changes
     if module.check_mode:
         module.exit_json(
-            changed=True,
-            msg=f"Would have {operation} database static role '{name}' if not in check mode",
-            raw=existing
+            changed=True, msg=f"Would have {operation} database static role '{name}' if not in check mode", raw=existing
         )
 
-    # Actually create or update the static role
-    db_static_roles.create_or_update_static_role(name, config)
+    # Create or update the static role
+    db_static_role_client.create_or_update_static_role(name, config)
 
-    # Read back the configuration to return to the user
-    result = db_static_roles.read_static_role(name)
+    # Read back the configuration to compare for idempotency
+    result = db_static_role_client.read_static_role(name)
 
+    # Check idempotency - compare the new result with what existed before
+    changed = not (result == existing)
+    if not changed:
+        msg = "The database static role already exists with the same data."
+    else:
+        msg = f"Database static role {name!r} {operation} successfully"
+
+    module.exit_json(changed=changed, msg=msg, raw=result)
+
+
+def ensure_absent(module: AnsibleModule, db_static_role_client: VaultDatabaseStaticRoles) -> None:
+    """Delete a database static role."""
+    name = module.params.get("name")
+
+    # Check if the static role exists before attempting deletion
+    # VaultSecretNotFoundError is raised if the role doesn't exist
+    try:
+        db_static_role_client.read_static_role(name)
+    except VaultSecretNotFoundError:
+        module.exit_json(
+            changed=False,
+            msg=f"Database static role {name!r} is already absent",
+        )
+
+    # In check mode, report what would happen without making changes
+    if module.check_mode:
+        module.exit_json(
+            changed=True,
+            msg=f"Would have deleted database static role {name!r} if not in check mode.",
+        )
+
+    # Actually delete the static role
+    db_static_role_client.delete_static_role(name)
     module.exit_json(
         changed=True,
-        msg=f"Database static role {name!r} {operation} successfully",
-        raw=result
+        msg=f"Database static role {name!r} deleted successfully",
     )
-
-    
 
 
 def main() -> None:
@@ -162,29 +214,35 @@ def main() -> None:
     argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
     argument_spec.update(
         dict(
-            name=dict(required=True),
             state=dict(default="present", choices=["present", "absent"]),
             database_mount_path=dict(default="database", aliases=["vault_database_mount_path"]),
+            name=dict(required=True),
             db_name=dict(),
             username=dict(),
+            rotation_period=dict(type="raw"),
+            rotation_schedule=dict(type="str"),
+            rotation_statements=dict(type="list", elements="str"),
+            skip_import_rotation=dict(type="bool"),
         )
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
         required_if=(("state", "present", ["db_name", "username"]),),
-        supports_check_mode=True
+        supports_check_mode=True,
     )
 
     client = get_authenticated_client(module)
 
     mount_path = module.params["database_mount_path"]
-    db_static_roles = VaultDatabaseStaticRoles(client, mount_path=mount_path)
+    db_static_role_client = VaultDatabaseStaticRoles(client, mount_path=mount_path)
 
     state = module.params["state"]
     try:
-        if state == "present":                                                                                                                
-            ensure_present(module, client, db_static_roles)  
-                                                                                      
+        if state == "present":
+            ensure_present(module, db_static_role_client)
+        elif state == "absent":
+            ensure_absent(module, db_static_role_client)
+
     except VaultSecretNotFoundError as e:
         module.exit_json(data={})
     except VaultPermissionError as e:

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -296,7 +296,7 @@ def main() -> None:
             rotation_schedule=dict(type="str"),
             rotation_window=dict(type="raw"),
             rotation_statements=dict(type="list", elements="str"),
-            skip_import_rotation=dict(type="bool"),
+            skip_import_rotation=dict(type="bool", default=False),
             credential_type=dict(
                 type="str", default="password", choices=["password", "rsa_private_key", "client_certificate"]
             ),

--- a/plugins/modules/database_static_role.py
+++ b/plugins/modules/database_static_role.py
@@ -186,9 +186,9 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils i
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_database import (
     VaultDatabaseStaticRoles,
+    build_config_params,
     compare_vault_configs,
     get_static_role,
-    build_config_params,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
     VaultApiError,

--- a/plugins/modules/database_static_role_info.py
+++ b/plugins/modules/database_static_role_info.py
@@ -8,13 +8,13 @@ from __future__ import absolute_import, division, print_function
 DOCUMENTATION = """
 ---
 module: database_static_role_info
-short_description: List available static roles or read configuration for a specific static role.
+short_description: List available static roles or read the configuration for a specific static role
 version_added: 1.2.0
 author: Hannah DeFazio (@hdefazio)
 description:
-  - This module retrieves configuration details for a specific Vault database static role.
-  - When a role name is provided, it returns its full settings; if the name is omitted,
-    the module returns a comprehensive list of all available database static roles within the specified mount path.
+  - This module retrieves information about database static roles in HashiCorp Vault.
+  - When a role name is provided, it returns the full configuration for that specific role.
+  - When no name is provided, it returns a list of all available static role names.
 options:
   name:
     description: The name of the database static role to read.
@@ -30,12 +30,12 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = """
-- name: List all available database static roles
-  hashicorp.vault.database_static_role_info:
-
 - name: Read configuration for a specific database static role
   hashicorp.vault.database_static_role_info:
     name: my-static-role
+
+- name: List all available database static roles
+  hashicorp.vault.database_static_role_info:
 """
 
 RETURN = """
@@ -47,38 +47,19 @@ static_roles:
   returned: always
   type: list
   elements: dict
-  contains:
-    name:
-      description: The name of the static role.
-      type: str
-      returned: always
-    db_name:
-      description: The database connection name.
-      type: str
-      returned: when O(name) is specified
-    username:
-      description: The database username managed by this role.
-      type: str
-      returned: when O(name) is specified
-    rotation_period:
-      description: The rotation period in seconds.
-      type: int
-      returned: when O(name) is specified
-    rotation_statements:
-      description: SQL statements executed during rotation.
-      type: list
-      elements: str
-      returned: when O(name) is specified
   sample:
-    # When listing all roles (no name specified)
-    - name: role1
-    - name: role2
-    # When reading a specific role (name specified)
-    - name: my-static-role
-      db_name: my-postgres-db
-      username: vault-user
-      rotation_period: 86400
-      rotation_statements: []
+    # When listing all roles (no name specified), only names are returned:
+    # [{"name": "role1"}, {"name": "role2"}]
+    # When reading a specific role (name specified), full details are returned:
+    [
+        {
+            "name": "my-static-role",
+            "db_name": "my-postgres-db",
+            "username": "vault-user",
+            "rotation_period": 86400,
+            "rotation_statements": []
+        }
+    ]
 """
 
 
@@ -92,13 +73,13 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
     get_authenticated_client,
 )
-from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_database import (
     VaultDatabaseStaticRoles,
+    get_static_role,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
     VaultApiError,
     VaultPermissionError,
-    VaultSecretNotFoundError,
 )
 
 
@@ -117,7 +98,8 @@ def main() -> None:
     )
 
     client = get_authenticated_client(module)
-    mount_path = module.params["database_mount_path"]
+
+    mount_path = module.params.get("database_mount_path")
     name = module.params.get("name")
 
     try:
@@ -125,17 +107,18 @@ def main() -> None:
 
         # Read specific role configuration
         if name:
-            data = db_static_role_client.read_static_role(name)
-            data.update({"name": name})
-            static_roles = [data]
+            data = get_static_role(db_static_role_client, name)
+            if data:
+                data.update({"name": name})
+                static_roles = [data]
+            else:
+                static_roles = []
         # List all roles
         else:
-            static_roles = [{"name": role_name} for role_name in db_static_role_client.list_static_roles() or []]
+            static_roles = [{"name": role_name} for role_name in db_static_role_client.list_static_roles()]
 
         module.exit_json(static_roles=static_roles)
 
-    except VaultSecretNotFoundError as e:
-        module.exit_json(static_roles=[])
     except VaultPermissionError as e:
         module.fail_json(msg=f"Permission denied: {e}")
     except VaultApiError as e:

--- a/plugins/modules/database_static_role_info.py
+++ b/plugins/modules/database_static_role_info.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-
 DOCUMENTATION = """
 ---
 module: database_static_role_info

--- a/plugins/modules/database_static_role_info.py
+++ b/plugins/modules/database_static_role_info.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+
+DOCUMENTATION = """
+---
+module: database_static_role_info
+short_description: List available static roles or read configuration for a specific static role.
+version_added: 1.2.0
+author: Hannah DeFazio (@hdefazio)
+description:
+  - This module retrieves configuration details for a specific Vault database static role.
+  - When a role name is provided, it returns its full settings; if the name is omitted,
+    the module returns a comprehensive list of all available database static roles within the specified mount path.
+options:
+  name:
+    description: The name of the database static role to read.
+    required: false
+    type: str
+  database_mount_path:
+    description: Database secret engine mount path.
+    type: str
+    default: database
+    aliases: [vault_database_mount_path]
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+"""
+
+EXAMPLES = """
+- name: List all available database static roles
+  hashicorp.vault.database_static_role_info:
+
+- name: Read configuration for a specific database static role
+  hashicorp.vault.database_static_role_info:
+    name: my-static-role
+"""
+
+RETURN = """
+static_roles:
+  description:
+    - The list of database static roles.
+    - When no O(name) is specified, only role names are returned.
+    - When O(name) is specified, full configuration details are returned.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    name:
+      description: The name of the static role.
+      type: str
+      returned: always
+    db_name:
+      description: The database connection name.
+      type: str
+      returned: when O(name) is specified
+    username:
+      description: The database username managed by this role.
+      type: str
+      returned: when O(name) is specified
+    rotation_period:
+      description: The rotation period in seconds.
+      type: int
+      returned: when O(name) is specified
+    rotation_statements:
+      description: SQL statements executed during rotation.
+      type: list
+      elements: str
+      returned: when O(name) is specified
+  sample:
+    # When listing all roles (no name specified)
+    - name: role1
+    - name: role2
+    # When reading a specific role (name specified)
+    - name: my-static-role
+      db_name: my-postgres-db
+      username: vault-user
+      rotation_period: 86400
+      rotation_statements: []
+"""
+
+
+__metaclass__ = type  # pylint: disable=C0103
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+    VaultDatabaseStaticRoles,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def main() -> None:
+    """Entry point for module execution"""
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            name=dict(required=False),
+            database_mount_path=dict(default="database", aliases=["vault_database_mount_path"]),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    client = get_authenticated_client(module)
+    mount_path = module.params["database_mount_path"]
+    name = module.params.get("name")
+
+    try:
+        db_static_role_client = VaultDatabaseStaticRoles(client, mount_path=mount_path)
+
+        # Read specific role configuration
+        if name:
+            data = db_static_role_client.read_static_role(name)
+            data.update({"name": name})
+            static_roles = [data]
+        # List all roles
+        else:
+            static_roles = [{"name": role_name} for role_name in db_static_role_client.list_static_roles() or []]
+
+        module.exit_json(static_roles=static_roles)
+
+    except VaultSecretNotFoundError as e:
+        module.exit_json(static_roles=[])
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/targets/database_static_role/aliases
+++ b/tests/integration/targets/database_static_role/aliases
@@ -1,0 +1,1 @@
+database_static_role_info

--- a/tests/integration/targets/database_static_role/defaults/main.yml
+++ b/tests/integration/targets/database_static_role/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+vault_approle_path: "approle-integration-tests"
+vault_database_mount_path: "database-conn-config-integration-tests"

--- a/tests/integration/targets/database_static_role/meta/main.yml
+++ b/tests/integration/targets/database_static_role/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_auth_token

--- a/tests/integration/targets/database_static_role/tasks/main.yml
+++ b/tests/integration/targets/database_static_role/tasks/main.yml
@@ -34,7 +34,6 @@
         that:
           - setup_db_conn is changed
 
-    # Test: Create static role with missing required parameters
     - name: Try to create static role without required parameters
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
@@ -81,8 +80,24 @@
       ansible.builtin.assert:
         that:
           - create_window_with_period is failed
-          - '"rotation_window" in create_window_with_period.msg'
-          - '"rotation_schedule" in create_window_with_period.msg'
+          - '"mutually exclusive" in create_window_with_period.msg'
+
+    # Test: Validation - Invalid duration format
+    - name: Try to create static role with invalid rotation_period format
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-validation"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "invalid_time"
+        skip_import_rotation: true
+      ignore_errors: true
+      register: create_invalid_duration
+
+    - name: Ensure task failed due to invalid duration format
+      ansible.builtin.assert:
+        that:
+          - create_invalid_duration is failed
+          - '"must be a valid duration string" in create_invalid_duration.msg'
 
     # Test: Create static role (check mode)
     # Note: skip_import_rotation prevents immediate password rotation, allowing tests
@@ -109,7 +124,6 @@
           - create_check_mode is changed
           - static_role_check.static_roles == []
 
-    # Test: Create static role
     - name: Create static role
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
@@ -138,7 +152,6 @@
           - static_role_read.static_roles[0].username == static_role_username
           - static_role_list.static_roles | selectattr('name', 'equalto', static_role_name) | list | length == 1
 
-    # Test: Create static role (idempotency)
     - name: Create static role again (idempotency test)
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
@@ -160,7 +173,49 @@
           - static_role_read_again.static_roles[0].db_name == db_connection_name
           - static_role_read_again.static_roles[0].username == static_role_username
 
-    # Test: Create static role with rotation_schedule and rotation_window
+    # Test: Idempotency with different duration format (equivalent values)
+    # This verifies that "24h", "86400s", and 86400 are treated as equivalent by Vault
+    - name: Verify idempotency with equivalent duration format (string)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "86400s"
+        skip_import_rotation: true
+      register: update_equivalent_duration_string
+
+    - name: Verify idempotency with equivalent duration format (integer)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: 86400
+        skip_import_rotation: true
+      register: update_equivalent_duration_int
+
+    - name: Validate that equivalent duration formats are idempotent
+      ansible.builtin.assert:
+        that:
+          - update_equivalent_duration_string is not changed
+          - update_equivalent_duration_int is not changed
+        fail_msg: "Module reported changed when updating with equivalent duration formats"
+
+    # Test: Verify that actual duration changes are detected
+    - name: Update static role with different duration value
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "48h"
+        skip_import_rotation: true
+      register: update_different_duration
+
+    - name: Validate that duration change is detected
+      ansible.builtin.assert:
+        that:
+          - update_different_duration is changed
+        fail_msg: "Module did not detect change when duration value was updated"
+
     - name: Create static role with rotation_schedule and rotation_window
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}-schedule"
@@ -189,6 +244,53 @@
         name: "{{ static_role_name }}-schedule"
         state: absent
 
+    - name: Create static role with RSA private key credential type
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-rsa"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}_rsa"
+        rotation_period: "24h"
+        credential_type: rsa_private_key
+        credential_config:
+          key_bits: 2048
+        skip_import_rotation: true
+      register: create_with_credential_config
+
+    - name: Read the RSA credential static role
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}-rsa"
+      register: rsa_role_read
+
+    - name: Validate that credential_type and credential_config were set
+      ansible.builtin.assert:
+        that:
+          - create_with_credential_config is changed
+          - rsa_role_read.static_roles | length == 1
+          - rsa_role_read.static_roles[0].credential_type == "rsa_private_key"
+
+    # Test: Idempotency with credential_config
+    - name: Create static role with RSA credential type again (idempotency)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-rsa"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}_rsa"
+        rotation_period: "24h"
+        credential_type: rsa_private_key
+        credential_config:
+          key_bits: 2048
+        skip_import_rotation: true
+      register: create_rsa_idempotency
+
+    - name: Validate idempotency works with credential_config
+      ansible.builtin.assert:
+        that:
+          - create_rsa_idempotency is not changed
+
+    - name: Delete the RSA-based static role
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-rsa"
+        state: absent
+
     # Test: List static roles returns only names when no specific role requested
     - name: List all static roles
       hashicorp.vault.database_static_role_info:
@@ -200,7 +302,6 @@
           - list_all_roles.static_roles | length > 0
           - list_all_roles.static_roles | selectattr('name', 'equalto', static_role_name) | list | length == 1
 
-    # Test: Delete static role (check mode)
     - name: Delete static role (check mode)
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
@@ -219,7 +320,6 @@
           - delete_check_mode is changed
           - static_role_after_check_delete.static_roles | length == 1
 
-    # Test: Delete static role
     - name: Delete static role
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
@@ -237,7 +337,6 @@
           - delete_static_role is changed
           - static_role_after_delete.static_roles == []
 
-    # Test: Delete static role (idempotency)
     - name: Delete static role again (idempotency test)
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
@@ -260,6 +359,12 @@
     - name: Delete schedule-based static role (cleanup)
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}-schedule"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete RSA-based static role (cleanup)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-rsa"
         state: absent
       ignore_errors: true
 

--- a/tests/integration/targets/database_static_role/tasks/main.yml
+++ b/tests/integration/targets/database_static_role/tasks/main.yml
@@ -47,6 +47,43 @@
           - create_missing_params is failed
           - '"db_name" in create_missing_params.msg or "username" in create_missing_params.msg'
 
+    # Test: Validation - Mutual exclusivity of rotation_period and rotation_schedule
+    - name: Try to create static role with both rotation_period and rotation_schedule
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-validation"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "24h"
+        rotation_schedule: "0 0 * * *"
+        skip_import_rotation: true
+      ignore_errors: true
+      register: create_mutual_exclusive
+
+    - name: Ensure task failed due to mutual exclusivity
+      ansible.builtin.assert:
+        that:
+          - create_mutual_exclusive is failed
+          - '"mutually exclusive" in create_mutual_exclusive.msg'
+
+    # Test: Validation - rotation_window cannot be used with rotation_period
+    - name: Try to create static role with rotation_window and rotation_period
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-validation"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "24h"
+        rotation_window: "3h"
+        skip_import_rotation: true
+      ignore_errors: true
+      register: create_window_with_period
+
+    - name: Ensure task failed due to invalid rotation_window usage
+      ansible.builtin.assert:
+        that:
+          - create_window_with_period is failed
+          - '"rotation_window" in create_window_with_period.msg'
+          - '"rotation_schedule" in create_window_with_period.msg'
+
     # Test: Create static role (check mode)
     # Note: skip_import_rotation prevents immediate password rotation, allowing tests
     # to verify Vault API operations without requiring an actual database connection.
@@ -123,6 +160,35 @@
           - static_role_read_again.static_roles[0].db_name == db_connection_name
           - static_role_read_again.static_roles[0].username == static_role_username
 
+    # Test: Create static role with rotation_schedule and rotation_window
+    - name: Create static role with rotation_schedule and rotation_window
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-schedule"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_schedule: "0 0 * * *"
+        rotation_window: "3h"
+        skip_import_rotation: true
+      register: create_with_schedule_window
+
+    - name: Read the schedule-based static role
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}-schedule"
+      register: schedule_role_read
+
+    - name: Validate that rotation_window works with rotation_schedule
+      ansible.builtin.assert:
+        that:
+          - create_with_schedule_window is changed
+          - schedule_role_read.static_roles | length == 1
+          - schedule_role_read.static_roles[0].rotation_schedule == "0 0 * * *"
+          - schedule_role_read.static_roles[0].rotation_window == 10800
+
+    - name: Delete the schedule-based static role
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-schedule"
+        state: absent
+
     # Test: List static roles returns only names when no specific role requested
     - name: List all static roles
       hashicorp.vault.database_static_role_info:
@@ -188,6 +254,12 @@
     - name: Delete static role (cleanup)
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete schedule-based static role (cleanup)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}-schedule"
         state: absent
       ignore_errors: true
 

--- a/tests/integration/targets/database_static_role/tasks/main.yml
+++ b/tests/integration/targets/database_static_role/tasks/main.yml
@@ -1,0 +1,198 @@
+---
+- name: Run database_static_role tests
+  module_defaults:
+    group/hashicorp.vault.vault:
+      url: "{{ vault_url }}"
+      namespace: "{{ vault_namespace }}"
+      auth_method: "token"
+      token: "{{ vault_token_from_setup_auth_token }}"
+      vault_approle_path: "{{ vault_approle_path }}"
+      database_mount_path: "{{ vault_database_mount_path }}"
+  vars:
+    # Database connection vars (fake values - no actual DB connection made)
+    db_connection_name: "test-db-conn-{{ vault_resource_suffix }}"
+    connection_url: "mysql://testuser:testpass@localhost:3306/testdb"
+    plugin_name: "mysql-database-plugin"
+    # Static role vars
+    static_role_name: "test-static-role-{{ vault_resource_suffix }}"
+    static_role_username: "test_vault_user"
+  block:
+    # Setup: Create database connection first (static roles require an existing connection)
+    # Note: verify_connection is false and static roles use skip_import_rotation=true because
+    # there's no actual database in the test environment. These tests verify Vault API operations
+    # (CRUD on static role config) work correctly, not actual credential rotation functionality.
+    - name: Create database connection for static role tests
+      hashicorp.vault.database_connection:
+        name: "{{ db_connection_name }}"
+        connection_url: "{{ connection_url }}"
+        verify_connection: false
+        plugin_name: "{{ plugin_name }}"
+      register: setup_db_conn
+
+    - name: Validate database connection was created
+      ansible.builtin.assert:
+        that:
+          - setup_db_conn is changed
+
+    # Test: Create static role with missing required parameters
+    - name: Try to create static role without required parameters
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+      ignore_errors: true
+      register: create_missing_params
+
+    - name: Ensure task failed due to missing parameters
+      ansible.builtin.assert:
+        that:
+          - create_missing_params is failed
+          - '"db_name" in create_missing_params.msg or "username" in create_missing_params.msg'
+
+    # Test: Create static role (check mode)
+    # Note: skip_import_rotation prevents immediate password rotation, allowing tests
+    # to verify Vault API operations without requiring an actual database connection.
+    # Credential rotation would still require a real database when performed.
+    - name: Create static role (check mode)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "24h"
+        skip_import_rotation: true
+      check_mode: true
+      register: create_check_mode
+
+    - name: Read static role to verify it was not created in check mode
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}"
+      register: static_role_check
+
+    - name: Validate that module reported change while the role was not created
+      ansible.builtin.assert:
+        that:
+          - create_check_mode is changed
+          - static_role_check.static_roles == []
+
+    # Test: Create static role
+    - name: Create static role
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "24h"
+        skip_import_rotation: true
+      register: create_static_role
+
+    - name: Read static role
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}"
+      register: static_role_read
+
+    - name: List all static roles
+      hashicorp.vault.database_static_role_info:
+      register: static_role_list
+
+    - name: Validate that module reported change and the role was created
+      ansible.builtin.assert:
+        that:
+          - create_static_role is changed
+          - static_role_read.static_roles | length == 1
+          - static_role_read.static_roles[0].name == static_role_name
+          - static_role_read.static_roles[0].db_name == db_connection_name
+          - static_role_read.static_roles[0].username == static_role_username
+          - static_role_list.static_roles | selectattr('name', 'equalto', static_role_name) | list | length == 1
+
+    # Test: Create static role (idempotency)
+    - name: Create static role again (idempotency test)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_role_username }}"
+        rotation_period: "24h"
+        skip_import_rotation: true
+      register: create_idempotency
+
+    - name: Read static role again
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}"
+      register: static_role_read_again
+
+    - name: Validate that module is idempotent for creation
+      ansible.builtin.assert:
+        that:
+          - create_idempotency is not changed
+          - static_role_read_again.static_roles[0].db_name == db_connection_name
+          - static_role_read_again.static_roles[0].username == static_role_username
+
+    # Test: List static roles returns only names when no specific role requested
+    - name: List all static roles
+      hashicorp.vault.database_static_role_info:
+      register: list_all_roles
+
+    - name: Validate list returns role names
+      ansible.builtin.assert:
+        that:
+          - list_all_roles.static_roles | length > 0
+          - list_all_roles.static_roles | selectattr('name', 'equalto', static_role_name) | list | length == 1
+
+    # Test: Delete static role (check mode)
+    - name: Delete static role (check mode)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        state: absent
+      check_mode: true
+      register: delete_check_mode
+
+    - name: Read static role to verify it was not deleted in check mode
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}"
+      register: static_role_after_check_delete
+
+    - name: Validate that module reported change while the role was not deleted
+      ansible.builtin.assert:
+        that:
+          - delete_check_mode is changed
+          - static_role_after_check_delete.static_roles | length == 1
+
+    # Test: Delete static role
+    - name: Delete static role
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        state: absent
+      register: delete_static_role
+
+    - name: Read static role after deletion
+      hashicorp.vault.database_static_role_info:
+        name: "{{ static_role_name }}"
+      register: static_role_after_delete
+
+    - name: Validate that module reported change and the role was deleted
+      ansible.builtin.assert:
+        that:
+          - delete_static_role is changed
+          - static_role_after_delete.static_roles == []
+
+    # Test: Delete static role (idempotency)
+    - name: Delete static role again (idempotency test)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        state: absent
+      register: delete_idempotency
+
+    - name: Validate that module is idempotent for deletion
+      ansible.builtin.assert:
+        that:
+          - delete_idempotency is not changed
+
+  always:
+    # Cleanup
+    - name: Delete static role (cleanup)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete database connection (cleanup)
+      hashicorp.vault.database_connection:
+        name: "{{ db_connection_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/unit/plugins/module_utils/test_vault_database_static_roles.py
+++ b/tests/unit/plugins/module_utils/test_vault_database_static_roles.py
@@ -15,14 +15,251 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client impor
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_database import (
     VaultDatabaseStaticRoles,
+    compare_vault_configs,
 )
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
     VaultApiError,
     VaultPermissionError,
     VaultSecretNotFoundError,
 )
+from ansible_collections.hashicorp.vault.plugins.modules.database_static_role import (
+    _validate_duration_format,
+    _normalize_duration_to_seconds,
+)
 
 TEST_ROLE_NAME = "test-role"
+
+
+class TestConfigsMatch:
+    """Test the compare_vault_configs utility function."""
+
+    def test_empty_existing_config_returns_false(self):
+        """Test that an empty existing config indicates a change (new creation)."""
+        existing = {}
+        user_config = {"db_name": "mydb", "username": "user", "rotation_period": 86400}
+
+        assert compare_vault_configs(existing, user_config) is False
+
+    def test_matching_configs_returns_true(self):
+        """Test that matching configs indicate no change."""
+        existing = {"db_name": "mydb", "username": "user", "rotation_period": 86400}
+        user_config = {"db_name": "mydb", "username": "user", "rotation_period": 86400}
+
+        assert compare_vault_configs(existing, user_config) is True
+
+    def test_vault_defaults_ignored(self):
+        """Test that Vault-added defaults don't affect comparison."""
+        # User only provided these keys (normalized)
+        user_config = {"db_name": "mydb", "username": "user", "rotation_period": 86400}
+
+        # Existing has user keys + Vault defaults
+        existing = {
+            "db_name": "mydb",
+            "username": "user",
+            "rotation_period": 86400,
+            "rotation_statements": [],  # Vault default
+            "credential_type": "password",  # Vault default
+        }
+
+        # Should match because user-provided keys are the same
+        assert compare_vault_configs(existing, user_config) is True
+
+    def test_user_key_changed_returns_false(self):
+        """Test that a change in a user-provided key is detected."""
+        existing = {"db_name": "mydb", "username": "user", "rotation_period": 86400}
+        user_config = {"db_name": "mydb", "username": "user", "rotation_period": 3600}  # Changed!
+
+        assert compare_vault_configs(existing, user_config) is False
+
+    def test_partial_user_config_match(self):
+        """Test that only user-provided keys are checked."""
+        # User only provided db_name and username (normalized)
+        user_config = {"db_name": "mydb", "username": "user"}
+
+        existing = {
+            "db_name": "mydb",
+            "username": "user",
+            "rotation_period": 86400,  # Not in user_config, so not checked
+        }
+
+        # Should match because user keys (db_name, username) are the same
+        assert compare_vault_configs(existing, user_config) is True
+
+    def test_nested_dict_vault_defaults_ignored(self):
+        """Test that Vault-added defaults in nested dicts don't affect comparison."""
+        # User provided credential_config with only key_bits
+        user_config = {
+            "db_name": "mydb",
+            "credential_type": "rsa_private_key",
+            "credential_config": {"key_bits": 2048}
+        }
+
+        # Vault added algorithm default to credential_config
+        existing = {
+            "db_name": "mydb",
+            "credential_type": "rsa_private_key",
+            "credential_config": {
+                "key_bits": 2048,
+                "algorithm": "rsa"  # Vault default
+            }
+        }
+
+        # Should match because user-provided keys in nested dict are the same
+        assert compare_vault_configs(existing, user_config) is True
+
+    def test_nested_dict_change_detected(self):
+        """Test that changes in nested dict values are detected."""
+        user_config = {
+            "credential_config": {"key_bits": 2048}
+        }
+
+        existing = {
+            "credential_config": {"key_bits": 4096}  # Different!
+        }
+
+        assert compare_vault_configs(existing, user_config) is False
+
+
+class TestNormalizeDurationToSeconds:
+    """Test the _normalize_duration_to_seconds helper function."""
+
+    def test_integer_passthrough(self):
+        """Test that integers are returned as-is."""
+        assert _normalize_duration_to_seconds(86400) == 86400
+        assert _normalize_duration_to_seconds(1) == 1
+        assert _normalize_duration_to_seconds(3600) == 3600
+
+    def test_hours_conversion(self):
+        """Test hour-based duration strings."""
+        assert _normalize_duration_to_seconds("24h") == 86400
+        assert _normalize_duration_to_seconds("1h") == 3600
+        assert _normalize_duration_to_seconds("72h") == 259200
+
+    def test_minutes_conversion(self):
+        """Test minute-based duration strings."""
+        assert _normalize_duration_to_seconds("60m") == 3600
+        assert _normalize_duration_to_seconds("1m") == 60
+        assert _normalize_duration_to_seconds("90m") == 5400
+
+    def test_seconds_conversion(self):
+        """Test second-based duration strings."""
+        assert _normalize_duration_to_seconds("86400s") == 86400
+        assert _normalize_duration_to_seconds("1s") == 1
+        assert _normalize_duration_to_seconds("3600s") == 3600
+
+    def test_milliseconds_conversion(self):
+        """Test millisecond-based duration strings."""
+        assert _normalize_duration_to_seconds("1000ms") == 1
+        assert _normalize_duration_to_seconds("500ms") == 0  # Rounds to 0 (banker's rounding: 0.5 → 0)
+        assert _normalize_duration_to_seconds("1500ms") == 2  # Rounds to 2 (banker's rounding: 1.5 → 2)
+
+    def test_microseconds_conversion(self):
+        """Test microsecond-based duration strings."""
+        assert _normalize_duration_to_seconds("1000000us") == 1
+        assert _normalize_duration_to_seconds("1000000µs") == 1
+
+    def test_nanoseconds_conversion(self):
+        """Test nanosecond-based duration strings."""
+        assert _normalize_duration_to_seconds("1000000000ns") == 1
+
+    def test_decimal_duration(self):
+        """Test duration strings with decimal values."""
+        assert _normalize_duration_to_seconds("1.5h") == 5400  # 1.5 hours = 5400 seconds
+        assert _normalize_duration_to_seconds("2.5m") == 150   # 2.5 minutes = 150 seconds
+
+    def test_equivalent_formats(self):
+        """Test that equivalent durations in different formats normalize to same value."""
+        # All represent 24 hours
+        assert _normalize_duration_to_seconds("24h") == 86400
+        assert _normalize_duration_to_seconds("1440m") == 86400
+        assert _normalize_duration_to_seconds("86400s") == 86400
+        assert _normalize_duration_to_seconds(86400) == 86400
+
+    def test_invalid_type_raises_error(self):
+        """Test that invalid types raise TypeError."""
+        with pytest.raises(TypeError, match="Duration must be int or str"):
+            _normalize_duration_to_seconds(None)
+        with pytest.raises(TypeError, match="Duration must be int or str"):
+            _normalize_duration_to_seconds([1, 2, 3])
+        with pytest.raises(TypeError, match="Duration must be int or str"):
+            _normalize_duration_to_seconds({"duration": "24h"})
+
+    def test_invalid_duration_string_raises_error(self):
+        """Test that invalid duration strings raise TypeError."""
+        # These should have been caught by validation, but test normalization fails fast
+        with pytest.raises(TypeError, match="Invalid duration format"):
+            _normalize_duration_to_seconds("invalid_time")
+        with pytest.raises(TypeError, match="Invalid duration format"):
+            _normalize_duration_to_seconds("24")  # Missing unit
+        with pytest.raises(TypeError, match="Invalid duration format"):
+            _normalize_duration_to_seconds("h24")  # Unit before number
+
+
+class TestValidateDurationFormat:
+    """Test the _validate_duration_format helper function."""
+
+    def test_valid_integer_duration(self):
+        """Test that positive integers are valid."""
+        _validate_duration_format(86400, "rotation_period")
+        _validate_duration_format(1, "rotation_period")
+        _validate_duration_format(3600, "rotation_window")
+
+    def test_invalid_integer_zero(self):
+        """Test that zero is invalid."""
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            _validate_duration_format(0, "rotation_period")
+
+    def test_invalid_negative_integer(self):
+        """Test that negative integers are invalid."""
+        with pytest.raises(ValueError, match="must be a positive integer"):
+            _validate_duration_format(-100, "rotation_period")
+
+    def test_valid_duration_strings(self):
+        """Test various valid duration string formats."""
+        valid_durations = [
+            "24h",
+            "72h",
+            "5m",
+            "30s",
+            "1h",
+            "86400s",
+            "1000ms",
+            "500us",
+            "500µs",
+            "1000000ns",
+            "1.5h",
+            "2.5m",
+        ]
+        for duration in valid_durations:
+            _validate_duration_format(duration, "rotation_period")
+
+    def test_invalid_duration_strings(self):
+        """Test invalid duration string formats."""
+        invalid_durations = [
+            "invalid_time",
+            "24",  # Missing unit
+            "h24",  # Unit before number
+            "24hours",  # Invalid unit
+            "24 h",  # Space between number and unit
+            "",  # Empty string
+            "abc",  # No number
+        ]
+        for duration in invalid_durations:
+            with pytest.raises(ValueError, match="must be a valid duration string"):
+                _validate_duration_format(duration, "rotation_period")
+
+    def test_invalid_types(self):
+        """Test that invalid types are rejected."""
+        invalid_values = [
+            ["list", "of", "times"],
+            {"key": "value"},
+            None,
+            True,
+            3.14,
+        ]
+        for value in invalid_values:
+            with pytest.raises(ValueError, match="must be an integer"):
+                _validate_duration_format(value, "rotation_period")
 
 
 @pytest.fixture
@@ -244,7 +481,7 @@ class TestCreateOrUpdateStaticRole:
         static_roles = VaultDatabaseStaticRoles(authenticated_client)
 
         with pytest.raises(TypeError, match="config must be a dict"):
-            static_roles.create_or_update_static_role(TEST_ROLE_NAME, "invalid_config")
+            static_roles.create_or_update_static_role(TEST_ROLE_NAME, "invalid_config")  # type: ignore[arg-type]
         authenticated_client._make_request.assert_not_called()
 
 

--- a/tests/unit/plugins/module_utils/test_vault_database_static_roles.py
+++ b/tests/unit/plugins/module_utils/test_vault_database_static_roles.py
@@ -23,8 +23,8 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
     VaultSecretNotFoundError,
 )
 from ansible_collections.hashicorp.vault.plugins.modules.database_static_role import (
-    _validate_duration_format,
     _normalize_duration_to_seconds,
+    _validate_duration_format,
 )
 
 TEST_ROLE_NAME = "test-role"
@@ -88,20 +88,13 @@ class TestConfigsMatch:
     def test_nested_dict_vault_defaults_ignored(self):
         """Test that Vault-added defaults in nested dicts don't affect comparison."""
         # User provided credential_config with only key_bits
-        user_config = {
-            "db_name": "mydb",
-            "credential_type": "rsa_private_key",
-            "credential_config": {"key_bits": 2048}
-        }
+        user_config = {"db_name": "mydb", "credential_type": "rsa_private_key", "credential_config": {"key_bits": 2048}}
 
         # Vault added algorithm default to credential_config
         existing = {
             "db_name": "mydb",
             "credential_type": "rsa_private_key",
-            "credential_config": {
-                "key_bits": 2048,
-                "algorithm": "rsa"  # Vault default
-            }
+            "credential_config": {"key_bits": 2048, "algorithm": "rsa"},  # Vault default
         }
 
         # Should match because user-provided keys in nested dict are the same
@@ -109,13 +102,9 @@ class TestConfigsMatch:
 
     def test_nested_dict_change_detected(self):
         """Test that changes in nested dict values are detected."""
-        user_config = {
-            "credential_config": {"key_bits": 2048}
-        }
+        user_config = {"credential_config": {"key_bits": 2048}}
 
-        existing = {
-            "credential_config": {"key_bits": 4096}  # Different!
-        }
+        existing = {"credential_config": {"key_bits": 4096}}  # Different!
 
         assert compare_vault_configs(existing, user_config) is False
 
@@ -165,7 +154,7 @@ class TestNormalizeDurationToSeconds:
     def test_decimal_duration(self):
         """Test duration strings with decimal values."""
         assert _normalize_duration_to_seconds("1.5h") == 5400  # 1.5 hours = 5400 seconds
-        assert _normalize_duration_to_seconds("2.5m") == 150   # 2.5 minutes = 150 seconds
+        assert _normalize_duration_to_seconds("2.5m") == 150  # 2.5 minutes = 150 seconds
 
     def test_equivalent_formats(self):
         """Test that equivalent durations in different formats normalize to same value."""


### PR DESCRIPTION
##### SUMMARY
This PR adds two new modules for managing HashiCorp Vault Database static roles:                                                                                       
  - database_static_role - Create, update, and delete database static roles                                                                                            
  - database_static_role_info - Read and list database static roles 

Bonus: Updated the README to include all of our new modules

Assisted by: Claude code

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`database_static_role` and `database_static_role_info`

