### PR TITLE
[Manual backport][stable-1] Run black on tests/ and plugins/ (#33)

### DIFF
--- a/plugins/module_utils/authentication.py
+++ b/plugins/module_utils/authentication.py
@@ -130,7 +130,7 @@ class AppRoleAuthenticator(Authenticator):
             headers["X-Vault-Namespace"] = vault_namespace
 
         try:
-            response = requests.post(login_url, json=payload, headers=headers)
+            response = requests.post(login_url, json=payload, headers=headers, timeout=90)
 
             response.raise_for_status()
 


### PR DESCRIPTION
Manual backport of https://github.com/ansible-collections/hashicorp.vault/pull/33 
Cherry-picked 2040d1698e6f126d98746f3123ceb786ed42ae7d

Note: Linter fixes (such as newline formatting) were already applied to stable-1 in PR #40, so they won't appear in this PR's diff.