### PR TITLE
Database static role credentials module

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -14,6 +14,7 @@ action_groups:
     - database_credential_rotation
     - database_static_role
     - database_static_role_info
+    - database_static_role_credentials
     - kv1_secret
     - kv1_secret_info
     - kv2_secret

--- a/plugins/modules/database_static_role_credentials.py
+++ b/plugins/modules/database_static_role_credentials.py
@@ -15,7 +15,7 @@ description:
     - Reads the current credentials for a database static role from HashiCorp Vault.
 options:
   database_mount_path:
-    description: Database secret engine mount path.
+    description: Database secrets engine mount path.
     type: str
     default: database
     aliases: [vault_database_mount_path]
@@ -30,7 +30,7 @@ options:
 extends_documentation_fragment:
   - hashicorp.vault.vault_auth.modules
 notes:
-  - For security reasons, this module should be used with B(no_log=true) and (register) functionalities.
+  - For security reasons, use C(no_log=true) and C(register) so raw credentials are not written to the task log.
 """
 
 EXAMPLES = """

--- a/plugins/modules/database_static_role_credentials.py
+++ b/plugins/modules/database_static_role_credentials.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, annotations, division, print_function
+
+
+DOCUMENTATION = """
+---
+module: database_static_role_credentials
+author: Hannah DeFazio (@hdefazio)
+version_added: "1.2.0"
+short_description: Read the credentials for a specific static role.
+description:
+    - Reads the current credentials for a database static role from HashiCorp Vault.
+options:
+  database_mount_path:
+    description: Database secret engine mount path.
+    type: str
+    default: database
+    aliases: [vault_database_mount_path]
+  name:
+    description: The name of the database static role to get credentials for.
+    required: true
+    type: str
+  read_snapshot_id:
+    description: Query parameter specifying the ID of a snapshot previously loaded into Vault.
+    required: false
+    type: str
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+notes:
+  - For security reasons, this module should be used with B(no_log=true) and (register) functionalities.
+"""
+
+EXAMPLES = """
+- name: Read credentials for a specific database static role
+  hashicorp.vault.database_static_role_credentials:
+    name: my-static-role
+  no_log: true
+  register: result
+"""
+
+RETURN = """
+static_role_credentials:
+  description: The credentials and metadata for the database static role.
+  type: dict
+  returned: always
+  sample:
+    {
+        "username": "static-user",
+        "password": "132ae3ef-5a64-7499-351e-bfe59f3a2a21",
+        "last_vault_rotation": "2019-05-06T15:26:42.525302-05:00",
+        "rotation_schedule": "0 0 * * SAT",
+        "rotation_window": 3600,
+        "ttl": 5000
+    }
+"""
+
+
+__metaclass__ = type  # pylint: disable=C0103
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_database import (
+    VaultDatabaseStaticRoles,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+    VaultSecretNotFoundError,
+)
+
+
+def main() -> None:
+    """Entry point for module execution"""
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            database_mount_path=dict(default="database", aliases=["vault_database_mount_path"]),
+            name=dict(type="str", required=True),
+            read_snapshot_id=dict(type="str", required=False),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    client = get_authenticated_client(module)
+
+    mount_path = module.params.get("database_mount_path")
+    name = module.params.get("name")
+    read_snapshot_id = module.params.get("read_snapshot_id")
+
+    try:
+        db_static_role_client = VaultDatabaseStaticRoles(client, mount_path=mount_path)
+
+        data = db_static_role_client.get_static_role_credentials(name, read_snapshot_id)
+
+        module.exit_json(changed=False, static_role_credentials=data)
+
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/database_static_role_credentials.py
+++ b/plugins/modules/database_static_role_credentials.py
@@ -5,7 +5,6 @@
 
 from __future__ import absolute_import, annotations, division, print_function
 
-
 DOCUMENTATION = """
 ---
 module: database_static_role_credentials
@@ -75,7 +74,6 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_database imp
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
     VaultApiError,
     VaultPermissionError,
-    VaultSecretNotFoundError,
 )
 
 

--- a/tests/integration/targets/database_static_role_credentials/defaults/main.yml
+++ b/tests/integration/targets/database_static_role_credentials/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+vault_approle_path: "approle-integration-tests"
+vault_database_mount_path: "database-conn-config-integration-tests"

--- a/tests/integration/targets/database_static_role_credentials/meta/main.yml
+++ b/tests/integration/targets/database_static_role_credentials/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - setup_vault_dev
+  - setup_postgresql_dev

--- a/tests/integration/targets/database_static_role_credentials/meta/main.yml
+++ b/tests/integration/targets/database_static_role_credentials/meta/main.yml
@@ -1,4 +1,3 @@
 ---
 dependencies:
-  - setup_vault_dev
-  - setup_postgresql_dev
+  - setup_vault_dev_with_postgresql

--- a/tests/integration/targets/database_static_role_credentials/tasks/main.yml
+++ b/tests/integration/targets/database_static_role_credentials/tasks/main.yml
@@ -1,0 +1,99 @@
+---
+- name: Run database_static_role_credentials tests
+  module_defaults:
+    group/hashicorp.vault.vault:
+      url: "{{ ansible_test_vault_url }}"
+      auth_method: "token"
+      token: "{{ ansible_test_vault_token }}"
+  vars:
+    static_app_user: ansible_test_user
+    static_app_user_initial_pass: "{{ lookup('password', 'dev/null length=16') }}"
+    db_connection_name: "test-db-conn-{{ vault_resource_suffix }}"
+    static_role_name: "test-static-role-{{ vault_resource_suffix }}"
+  block:
+    # Setup: Create actual user in PostgreSQL
+    - name: Create database user for static role testing
+      postgres_execute:
+        user: postgres
+        password: "{{ ansible_postgresql_root_password }}"
+        database_port: "{{ ansible_postgresql_port }}"
+        connection_retries: 10
+        commands:
+          - "CREATE USER {{ static_app_user }} WITH PASSWORD '{{ static_app_user_initial_pass }}';"
+          - "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{ static_app_user }};"
+
+    - name: Verify we can connect with the new user
+      postgres_execute:
+        user: "{{ static_app_user }}"
+        password: "{{ static_app_user_initial_pass }}"
+        database_port: "{{ ansible_postgresql_port }}"
+
+    # Setup: Create database connection in Vault
+    - name: Create database connection
+      hashicorp.vault.database_connection:
+        name: "{{ db_connection_name }}"
+        plugin_name: "postgresql-database-plugin"
+        allowed_roles:
+          - "{{ static_role_name }}"
+        connection_url: "{% raw %}postgresql://{{username}}:{{password}}@{% endraw %}localhost:{{ ansible_postgresql_port }}/postgres?sslmode=disable"
+        username: postgres
+        password: "{{ ansible_postgresql_root_password }}"
+      register: setup_db_conn
+
+    - name: Validate database connection was created
+      ansible.builtin.assert:
+        that:
+          - setup_db_conn is changed
+
+    # Setup: Create static role (Vault will immediately rotate the user's password)
+    - name: Create static role
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        db_name: "{{ db_connection_name }}"
+        username: "{{ static_app_user }}"
+        rotation_period: "24h"
+      register: create_static_role
+
+    - name: Validate static role was created
+      ansible.builtin.assert:
+        that:
+          - create_static_role is changed
+
+    # Test: Read credentials for static role
+    - name: Read static role credentials
+      hashicorp.vault.database_static_role_credentials:
+        name: "{{ static_role_name }}"
+      register: read_credentials
+      no_log: true
+
+    - name: Validate credentials were returned
+      ansible.builtin.assert:
+        that:
+          - read_credentials is not changed
+          - read_credentials.static_role_credentials is defined
+          - read_credentials.static_role_credentials.username is defined
+          - read_credentials.static_role_credentials.username == static_app_user
+          - read_credentials.static_role_credentials.password is defined
+          - read_credentials.static_role_credentials.last_vault_rotation is defined
+          - read_credentials.static_role_credentials.ttl is defined
+
+    # Test: Verify the credentials actually work by connecting to PostgreSQL
+    - name: Test credentials work with PostgreSQL
+      postgres_execute:
+        user: "{{ read_credentials.static_role_credentials.username }}"
+        password: "{{ read_credentials.static_role_credentials.password }}"
+        database_port: "{{ ansible_postgresql_port }}"
+
+  always:
+    # Cleanup
+    - name: Delete static role (cleanup)
+      hashicorp.vault.database_static_role:
+        name: "{{ static_role_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete database connection (cleanup)
+      hashicorp.vault.database_connection:
+        name: "{{ db_connection_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/database_static_role_credentials/tasks/main.yml
+++ b/tests/integration/targets/database_static_role_credentials/tasks/main.yml
@@ -4,29 +4,16 @@
     group/hashicorp.vault.vault:
       url: "{{ ansible_test_vault_url }}"
       auth_method: "token"
-      token: "{{ ansible_test_vault_token }}"
+      token: "{{ ansible_test_vault_root_token }}"
   vars:
-    static_app_user: ansible_test_user
-    static_app_user_initial_pass: "{{ lookup('password', 'dev/null length=16') }}"
     db_connection_name: "test-db-conn-{{ vault_resource_suffix }}"
     static_role_name: "test-static-role-{{ vault_resource_suffix }}"
   block:
-    # Setup: Create actual user in PostgreSQL
-    - name: Create database user for static role testing
-      postgres_execute:
-        user: postgres
-        password: "{{ ansible_postgresql_root_password }}"
-        database_port: "{{ ansible_postgresql_port }}"
-        connection_retries: 10
-        commands:
-          - "CREATE USER {{ static_app_user }} WITH PASSWORD '{{ static_app_user_initial_pass }}';"
-          - "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {{ static_app_user }};"
-
-    - name: Verify we can connect with the new user
-      postgres_execute:
-        user: "{{ static_app_user }}"
-        password: "{{ static_app_user_initial_pass }}"
-        database_port: "{{ ansible_postgresql_port }}"
+    # Verify we can connect with the pre-existing user before Vault manages it
+    - name: Verify initial database connection
+      postgres_connect:
+        db_user: "{{ ansible_test_db_user }}"
+        db_user_password: "{{ ansible_test_db_user_password }}"
 
     # Setup: Create database connection in Vault
     - name: Create database connection
@@ -35,9 +22,9 @@
         plugin_name: "postgresql-database-plugin"
         allowed_roles:
           - "{{ static_role_name }}"
-        connection_url: "{% raw %}postgresql://{{username}}:{{password}}@{% endraw %}localhost:{{ ansible_postgresql_port }}/postgres?sslmode=disable"
-        username: postgres
-        password: "{{ ansible_postgresql_root_password }}"
+        connection_url: "{% raw %}postgresql://{{username}}:{{password}}@{% endraw %}{{ ansible_test_postgres_container_name }}:5432/postgres?sslmode=disable"
+        username: "{{ ansible_test_db_admin_user }}"
+        password: "{{ ansible_test_db_admin_user_password }}"
       register: setup_db_conn
 
     - name: Validate database connection was created
@@ -50,7 +37,7 @@
       hashicorp.vault.database_static_role:
         name: "{{ static_role_name }}"
         db_name: "{{ db_connection_name }}"
-        username: "{{ static_app_user }}"
+        username: "{{ ansible_test_db_user }}"
         rotation_period: "24h"
       register: create_static_role
 
@@ -72,17 +59,30 @@
           - read_credentials is not changed
           - read_credentials.static_role_credentials is defined
           - read_credentials.static_role_credentials.username is defined
-          - read_credentials.static_role_credentials.username == static_app_user
+          - read_credentials.static_role_credentials.username == ansible_test_db_user
           - read_credentials.static_role_credentials.password is defined
           - read_credentials.static_role_credentials.last_vault_rotation is defined
           - read_credentials.static_role_credentials.ttl is defined
 
+    # Test: Verify the old password no longer works
+    - name: Ensure old credentials no longer work
+      postgres_connect:
+        db_user: "{{ ansible_test_db_user }}"
+        db_user_password: "{{ ansible_test_db_user_password }}"
+      register: old_login
+      ignore_errors: true
+
+    - name: Validate that old password failed after Vault rotation
+      ansible.builtin.assert:
+        that:
+          - old_login is failed
+          - '"password authentication failed for user" in old_login.msg'
+
     # Test: Verify the credentials actually work by connecting to PostgreSQL
-    - name: Test credentials work with PostgreSQL
-      postgres_execute:
-        user: "{{ read_credentials.static_role_credentials.username }}"
-        password: "{{ read_credentials.static_role_credentials.password }}"
-        database_port: "{{ ansible_postgresql_port }}"
+    - name: Test new credentials work with PostgreSQL
+      postgres_connect:
+        db_user: "{{ read_credentials.static_role_credentials.username }}"
+        db_user_password: "{{ read_credentials.static_role_credentials.password }}"
 
   always:
     # Cleanup


### PR DESCRIPTION
##### SUMMARY
This pr adds a new `database_static_role_credentials` module to read current credentials for database static roles from HashiCorp Vault.

Assisted by: Claude code

Note: This pr depends on https://github.com/ansible-collections/hashicorp.vault/pull/70 and https://github.com/ansible-collections/hashicorp.vault/pull/104 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`database_static_role_credentials`
