### PR TITLE
remove dev/null from integration tests

### DIFF
--- a/tests/integration/dev/null
+++ b/tests/integration/dev/null
@@ -1,1 +1,0 @@
-5mDG2b6bZujO


### PR DESCRIPTION
This PR addresses the accidental inclusion of sensitive credentials in the repository. Since the team has opted for credential rotation over a history rewrite, this change focuses on cleaning the current state of main.

Removes:
`tests/integration/dev` and subdirectories
