### PR TITLE
Add timeout and retries parameters to Vault API calls

### DIFF
--- a/changelogs/fragments/add-connection-name-alias-database-role.yml
+++ b/changelogs/fragments/add-connection-name-alias-database-role.yml
@@ -2,4 +2,4 @@
 minor_changes:
   - database_role - add ``connection_name`` alias for ``db_name`` parameter to align
     with ``database_connection`` module
-    (https://github.com/ansible-collections/hashicorp.vault/pull/XXXX).
+    (https://github.com/ansible-collections/hashicorp.vault/pull/133).

--- a/changelogs/fragments/add-connection-name-alias-database-role.yml
+++ b/changelogs/fragments/add-connection-name-alias-database-role.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - database_role - add ``connection_name`` alias for ``db_name`` parameter to align
+    with ``database_connection`` module
+    (https://github.com/ansible-collections/hashicorp.vault/pull/XXXX).

--- a/changelogs/fragments/add-timeout-retries-params.yml
+++ b/changelogs/fragments/add-timeout-retries-params.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - Add ``timeout`` and ``retries`` parameters to modules and lookup plugins to configure
+    request timeouts and automatic retry logic for Vault API calls
+    (https://github.com/ansible-collections/hashicorp.vault/pull/XXXX).

--- a/changelogs/fragments/add-timeout-retries-params.yml
+++ b/changelogs/fragments/add-timeout-retries-params.yml
@@ -2,4 +2,4 @@
 minor_changes:
   - Add ``timeout`` and ``retries`` parameters to modules and lookup plugins to configure
     request timeouts and automatic retry logic for Vault API calls
-    (https://github.com/ansible-collections/hashicorp.vault/pull/XXXX).
+    (https://github.com/ansible-collections/hashicorp.vault/pull/133).

--- a/plugins/doc_fragments/vault_auth.py
+++ b/plugins/doc_fragments/vault_auth.py
@@ -79,6 +79,22 @@ options:
       - This variable accepts either a simple string or a JSON-formatted string.
     type: raw
     version_added: 1.3.0
+  timeout:
+    description:
+      - Timeout for Vault API requests in seconds.
+      - If not specified, the value of the E(VAULT_TIMEOUT) environment variable will be used.
+      - When not set, requests will wait indefinitely for a response.
+    type: int
+    version_added: 1.3.0
+  retries:
+    description:
+      - Number of retries to perform on failed requests, or a dictionary of retry configuration.
+      - When set to an integer, retries that many times on connection errors and retryable status codes.
+      - When set to a dict, it is passed as keyword arguments to C(urllib3.util.retry.Retry).
+      - If not specified, the value of the E(VAULT_RETRIES) environment variable will be used.
+      - This variable accepts either a simple integer or a JSON-formatted string.
+    type: raw
+    version_added: 1.3.0
 notes:
   - Authentication is required for all Vault operations.
   - Token authentication is the default method.
@@ -162,6 +178,23 @@ options:
     type: raw
     env:
       - name: VAULT_PROXIES
+    version_added: 1.3.0
+  timeout:
+    description:
+      - Timeout for Vault API requests in seconds.
+      - When not set, requests will wait indefinitely for a response.
+    type: int
+    env:
+      - name: VAULT_TIMEOUT
+    version_added: 1.3.0
+  retries:
+    description:
+      - Number of retries to perform on failed requests, or a dictionary of retry configuration.
+      - When set to an integer, retries that many times on connection errors and retryable status codes.
+      - When set to a dict, it is passed as keyword arguments to C(urllib3.util.retry.Retry).
+    type: raw
+    env:
+      - name: VAULT_RETRIES
     version_added: 1.3.0
 notes:
   - Authentication is required for all Vault operations.

--- a/plugins/doc_fragments/vault_auth.py
+++ b/plugins/doc_fragments/vault_auth.py
@@ -88,9 +88,14 @@ options:
     version_added: 1.3.0
   retries:
     description:
-      - Number of retries to perform on failed requests, or a dictionary of retry configuration.
-      - When set to an integer, retries that many times on connection errors and retryable status codes.
-      - When set to a dict, it is passed as keyword arguments to C(urllib3.util.retry.Retry).
+    - Configure automatic retries for Vault API requests made through C(VaultClient).
+    - When set to an integer, equivalent to C(urllib3.util.retry.Retry(total=N)).
+      This retries transient transport failures (connection errors, read timeouts, and similar).
+      It does not retry HTTP error status codes by default.
+    - When set to a dict, passed as keyword arguments to C(urllib3.util.retry.Retry).
+      Use this to retry specific HTTP status codes (C(status_forcelist)), include POST
+      (C(allowed_methods)), or tune backoff (C(backoff_factor)).
+    - Retries apply to API calls made after authentication, not to AppRole login requests.
       - If not specified, the value of the E(VAULT_RETRIES) environment variable will be used.
       - This variable accepts either a simple integer or a JSON-formatted string.
     type: raw

--- a/plugins/module_utils/args_common.py
+++ b/plugins/module_utils/args_common.py
@@ -41,4 +41,12 @@ AUTH_ARG_SPEC = {
         "type": "raw",
         "fallback": (env_fallback, ["VAULT_PROXIES"]),
     },
+    "timeout": {
+        "type": "int",
+        "fallback": (env_fallback, ["VAULT_TIMEOUT"]),
+    },
+    "retries": {
+        "type": "raw",
+        "fallback": (env_fallback, ["VAULT_RETRIES"]),
+    },
 }

--- a/plugins/module_utils/authentication.py
+++ b/plugins/module_utils/authentication.py
@@ -77,6 +77,7 @@ class AppRoleAuthenticator(Authenticator):
         secret_id,
         vault_namespace=None,
         approle_path="approle",
+        timeout=None,
     ):
         """
         Authenticate the client using AppRole credentials.
@@ -101,10 +102,14 @@ class AppRoleAuthenticator(Authenticator):
         if not role_id or not secret_id:
             raise VaultCredentialsError("role_id and secret_id are required for AppRole authentication.")
 
-        token = self._login_with_approle(vault_address, role_id, secret_id, vault_namespace, approle_path)
+        token = self._login_with_approle(
+            vault_address, role_id, secret_id, vault_namespace, approle_path, timeout=timeout
+        )
         client.set_token(token)
 
-    def _login_with_approle(self, vault_address, role_id, secret_id, vault_namespace=None, approle_path="approle"):
+    def _login_with_approle(
+        self, vault_address, role_id, secret_id, vault_namespace=None, approle_path="approle", timeout=None
+    ):
         """
         Login to Vault using AppRole credentials.
 
@@ -130,7 +135,7 @@ class AppRoleAuthenticator(Authenticator):
             headers["X-Vault-Namespace"] = vault_namespace
 
         try:
-            response = requests.post(login_url, json=payload, headers=headers, timeout=90)
+            response = requests.post(login_url, json=payload, headers=headers, timeout=timeout or 90)
 
             response.raise_for_status()
 
@@ -183,6 +188,7 @@ class VaultLogin:
         auth_method: str,
         vault_namespace: Optional[str] = None,
         mount_path: Optional[str] = None,
+        timeout: Optional[int] = None,
     ) -> None:
         """
         Initializes the Vault Login API client.
@@ -192,6 +198,7 @@ class VaultLogin:
             auth_method (str): The auth method (e.g., approle, alicloud, aws, azure, etc).
             vault_namespace (str, optional): Vault namespace for Enterprise
             custom_mount_path: Custom path for the auth method. If omitted, the auth method name is used as the mount point
+            timeout (int, optional): Request timeout in seconds.
 
         Returns:
           None
@@ -203,6 +210,7 @@ class VaultLogin:
         self._auth_method = auth_method.lower()
         self._namespace = vault_namespace
         self._mount_path = mount_path if mount_path is not None else auth_method
+        self._timeout = timeout
 
     def validate_login_params(self, **kwargs: Any) -> None:
         """
@@ -258,7 +266,7 @@ class VaultLogin:
             headers["X-Vault-Namespace"] = self._namespace
 
         try:
-            response = requests.post(login_url, json=kwargs, headers=headers, timeout=90)
+            response = requests.post(login_url, json=kwargs, headers=headers, timeout=self._timeout or 90)
             response.raise_for_status()
             raw_response = response.json()
 

--- a/plugins/module_utils/vault_auth_utils.py
+++ b/plugins/module_utils/vault_auth_utils.py
@@ -37,6 +37,7 @@ def authenticate_module(module, client):
         VaultCredentialsError: If required authentication parameters are missing
     """
     auth_method = module.params["auth_method"]
+    timeout = module.params["timeout"]
 
     if auth_method == "token":
         token = module.params["token"]
@@ -64,6 +65,8 @@ def authenticate_module(module, client):
         vault_approle_path = module.params["vault_approle_path"]
         if vault_approle_path is not None:
             params.update({"approle_path": vault_approle_path})
+        if timeout is not None:
+            params.update({"timeout": timeout})
 
         AppRoleAuthenticator().authenticate(client, **params)
 
@@ -92,6 +95,8 @@ def get_authenticated_client(module):
     ca_cert = module.params["ca_cert"]
     tls_skip_verify = module.params["tls_skip_verify"]
     proxies = module.params["proxies"]
+    timeout = module.params["timeout"]
+    retries = module.params["retries"]
 
     try:
         # Create client
@@ -101,6 +106,8 @@ def get_authenticated_client(module):
             ca_certificate=ca_cert,
             tls_skip_verify=tls_skip_verify,
             proxies=proxies,
+            timeout=timeout,
+            retries=retries,
         )
 
         # Authenticate using module parameters

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -13,6 +13,8 @@ from typing import Dict, Optional, Union
 
 try:
     import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
 except ImportError as imp_exc:
     REQUESTS_IMPORT_ERROR = imp_exc
 else:
@@ -93,6 +95,8 @@ class VaultClient:
         ca_certificate: Optional[str] = None,
         tls_skip_verify: bool = None,
         proxies: Optional[Union[str, Dict[str, str]]] = None,
+        timeout: Optional[int] = None,
+        retries: Optional[Union[int, str, Dict]] = None,
     ) -> None:
         """
         Initialize the Vault client.
@@ -105,6 +109,8 @@ class VaultClient:
             vault_namespace (str): Vault Enterprise namespace (use "root" for OSS Vault)
             ca_certificate (str): Path to an optional custom CA certificate file.
             tls_skip_verify (bool): When set to true, skip tls verification.
+            timeout (int): Request timeout in seconds.
+            retries: Retry configuration (int, dict, or string).
 
         Raises:
             VaultConfigurationError: If vault_address or vault_namespace are empty/None
@@ -120,10 +126,17 @@ class VaultClient:
         self.vault_address = vault_address
         self.vault_namespace = vault_namespace
         self.vault_token = None
+        self.timeout = int(timeout) if timeout is not None else None
 
         # Set up HTTP session with namespace header
         self.session = requests.Session()
         self.session.headers.update({"X-Vault-Namespace": vault_namespace})
+
+        if retries is not None:
+            retry_config = self._build_retry(retries)
+            adapter = HTTPAdapter(max_retries=retry_config)
+            self.session.mount('https://', adapter)
+            self.session.mount('http://', adapter)
 
         logger.info("Initialized VaultClient for %s", vault_address)
         self.secrets = Secrets(self)
@@ -193,6 +206,28 @@ class VaultClient:
                 }
             return proxies
 
+    @staticmethod
+    def _build_retry(retries):
+        if isinstance(retries, str):
+            try:
+                retries = int(retries)
+            except ValueError:
+                try:
+                    retries = json.loads(retries)
+                except json.JSONDecodeError:
+                    raise VaultConfigurationError(
+                        f'retries must be an integer or a JSON dictionary string, got: {retries!r}'
+                    )
+        if isinstance(retries, int):
+            return Retry(total=retries)
+        elif isinstance(retries, dict):
+            try:
+                return Retry(**retries)
+            except TypeError as e:
+                raise VaultConfigurationError(f'Invalid retries configuration: {e}') from e
+        else:
+            raise VaultConfigurationError(f'retries must be an integer or a dictionary, got {type(retries).__name__}')
+
     @property
     def token(self) -> Optional[str]:
         """
@@ -224,6 +259,8 @@ class VaultClient:
 
         url = f"{self.vault_address}/{path}"
         logger.debug("Making %s request to %s with params: %s", method, url, kwargs.get("params"))
+        if self.timeout is not None and 'timeout' not in kwargs:
+            kwargs['timeout'] = self.timeout
         try:
             response = self.session.request(method, url, **kwargs)
             response.raise_for_status()

--- a/plugins/modules/database_role.py
+++ b/plugins/modules/database_role.py
@@ -35,6 +35,7 @@ options:
       - Name of the database connection to use.
       - Required when O(state=present).
     type: str
+    aliases: [connection_name]
   creation_statements:
     description:
       - SQL statements to execute when creating database credentials.
@@ -238,7 +239,7 @@ def main():
             # Role parameters
             mount_path=dict(type='str', default='database'),
             role_name=dict(type='str', required=True),
-            db_name=dict(type='str'),
+            db_name=dict(type='str', aliases=['connection_name']),
             creation_statements=dict(type='list', elements='str'),
             default_ttl=dict(type='int'),
             max_ttl=dict(type='int'),

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -26,6 +26,7 @@ class VaultLookupBase(LookupBase):
     def _authenticate(self) -> None:
 
         auth_method = self.get_option("auth_method")
+        timeout = self.get_option("timeout")
 
         try:
             if auth_method == "token":
@@ -41,6 +42,8 @@ class VaultLookupBase(LookupBase):
                 vault_approle_path = self.get_option("vault_approle_path")
                 if vault_approle_path is not None:
                     params.update({"approle_path": vault_approle_path})
+                if timeout is not None:
+                    params.update({"timeout": timeout})
 
                 AppRoleAuthenticator().authenticate(self.client, **params)
         except VaultError as e:
@@ -55,11 +58,15 @@ class VaultLookupBase(LookupBase):
         ca_cert = self.get_option("ca_cert")
         tls_skip_verify = self.get_option("tls_skip_verify")
         proxies = self.get_option("proxies")
+        timeout = self.get_option("timeout")
+        retries = self.get_option("retries")
         self.client = VaultClient(
             vault_address=vault_address,
             vault_namespace=vault_namespace,
             ca_certificate=ca_cert,
             tls_skip_verify=tls_skip_verify,
             proxies=proxies,
+            timeout=timeout,
+            retries=retries,
         )
         self._authenticate()

--- a/tests/unit/plugins/lookup/test_kv2_secret_get.py
+++ b/tests/unit/plugins/lookup/test_kv2_secret_get.py
@@ -162,6 +162,8 @@ class TestKv2SecretGetLookup:
                 ca_certificate=None,
                 tls_skip_verify=None,
                 proxies=None,
+                timeout=None,
+                retries=None,
             )
 
             # Verify authentication was called

--- a/tests/unit/plugins/module_utils/test_authentication.py
+++ b/tests/unit/plugins/module_utils/test_authentication.py
@@ -188,3 +188,29 @@ class TestAppRoleAuthenticator:
 
         with pytest.raises(VaultAppRoleLoginError, match="Invalid response format from Vault"):
             authenticator.authenticate(mock_client, **auth_params)
+
+    @patch("requests.post")
+    def test_authenticate_with_custom_timeout(
+        self, mock_post, mock_client, authenticator, successful_mock_response, auth_params
+    ):
+        """Test AppRole authentication uses custom timeout when provided."""
+        successful_mock_response.json.return_value = {"auth": {"client_token": "hvs.timeout"}}
+        mock_post.return_value = successful_mock_response
+
+        authenticator.authenticate(mock_client, **auth_params, timeout=30)
+
+        args, kwargs = mock_post.call_args
+        assert kwargs['timeout'] == 30
+
+    @patch("requests.post")
+    def test_authenticate_default_timeout(
+        self, mock_post, mock_client, authenticator, successful_mock_response, auth_params
+    ):
+        """Test AppRole authentication uses 90s default timeout when not specified."""
+        successful_mock_response.json.return_value = {"auth": {"client_token": "hvs.default"}}
+        mock_post.return_value = successful_mock_response
+
+        authenticator.authenticate(mock_client, **auth_params)
+
+        args, kwargs = mock_post.call_args
+        assert kwargs['timeout'] == 90

--- a/tests/unit/plugins/module_utils/test_vault_client.py
+++ b/tests/unit/plugins/module_utils/test_vault_client.py
@@ -24,6 +24,9 @@ from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions i
     VaultSecretNotFoundError,
 )
 
+MOCK_HTTP_ADAPTER = 'ansible_collections.hashicorp.vault.plugins.module_utils.vault_client.HTTPAdapter'
+MOCK_RETRY = 'ansible_collections.hashicorp.vault.plugins.module_utils.vault_client.Retry'
+
 MOCK_REQUESTS_SESSION = "ansible_collections.hashicorp.vault.plugins.module_utils.vault_client.requests.Session"
 
 
@@ -100,6 +103,111 @@ class TestVaultClient:
         assert mock_session.headers.update.call_count == 3
 
         mock_session.headers.update.assert_called_with({"X-Vault-Token": "hvs.third-token"})
+
+
+class TestVaultClientTimeout:
+    """Test VaultClient timeout configuration."""
+
+    def test_init_with_timeout(self, mock_session_class, mock_session):
+        """Test that timeout is stored on the client instance."""
+        client = VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+            timeout=30,
+        )
+        assert client.timeout == 30
+
+    def test_init_without_timeout(self, mock_session_class, mock_session):
+        """Test that timeout defaults to None."""
+        client = VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+        )
+        assert client.timeout is None
+
+    def test_init_timeout_string_conversion(self, mock_session_class, mock_session):
+        """Test that string timeout from env var is converted to int."""
+        client = VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+            timeout='30',
+        )
+        assert client.timeout == 30
+
+
+class TestVaultClientRetries:
+    """Test VaultClient retry configuration."""
+
+    def test_init_with_retries_int(self, mock_session_class, mock_session):
+        """Test that integer retries mounts an HTTPAdapter on the session."""
+        with patch(MOCK_RETRY) as mock_retry_cls, patch(MOCK_HTTP_ADAPTER) as mock_adapter_cls:
+            mock_retry_instance = Mock()
+            mock_retry_cls.return_value = mock_retry_instance
+            mock_adapter_instance = Mock()
+            mock_adapter_cls.return_value = mock_adapter_instance
+
+            VaultClient(
+                vault_address='https://vault.example.com:8200',
+                vault_namespace='test-namespace',
+                retries=3,
+            )
+
+            mock_retry_cls.assert_called_once_with(total=3)
+            mock_adapter_cls.assert_called_once_with(max_retries=mock_retry_instance)
+            assert mock_session.mount.call_count == 2
+            mock_session.mount.assert_any_call('https://', mock_adapter_instance)
+            mock_session.mount.assert_any_call('http://', mock_adapter_instance)
+
+    def test_init_with_retries_dict(self, mock_session_class, mock_session):
+        """Test that dict retries passes kwargs to Retry."""
+        with patch(MOCK_RETRY) as mock_retry_cls, patch(MOCK_HTTP_ADAPTER):
+            retries_config = {'total': 3, 'backoff_factor': 0.5}
+            VaultClient(
+                vault_address='https://vault.example.com:8200',
+                vault_namespace='test-namespace',
+                retries=retries_config,
+            )
+
+            mock_retry_cls.assert_called_once_with(total=3, backoff_factor=0.5)
+
+    def test_init_with_retries_string_int(self, mock_session_class, mock_session):
+        """Test that string integer retries from env var is parsed correctly."""
+        with patch(MOCK_RETRY) as mock_retry_cls, patch(MOCK_HTTP_ADAPTER):
+            VaultClient(
+                vault_address='https://vault.example.com:8200',
+                vault_namespace='test-namespace',
+                retries='3',
+            )
+
+            mock_retry_cls.assert_called_once_with(total=3)
+
+    def test_init_with_retries_string_json(self, mock_session_class, mock_session):
+        """Test that JSON string retries from env var is parsed correctly."""
+        with patch(MOCK_RETRY) as mock_retry_cls, patch(MOCK_HTTP_ADAPTER):
+            VaultClient(
+                vault_address='https://vault.example.com:8200',
+                vault_namespace='test-namespace',
+                retries='{"total": 3}',
+            )
+
+            mock_retry_cls.assert_called_once_with(total=3)
+
+    def test_init_with_retries_invalid_string(self, mock_session_class, mock_session):
+        """Test that invalid string retries raises VaultConfigurationError."""
+        with pytest.raises(VaultConfigurationError, match='retries must be an integer or a JSON dictionary string'):
+            VaultClient(
+                vault_address='https://vault.example.com:8200',
+                vault_namespace='test-namespace',
+                retries='invalid',
+            )
+
+    def test_init_without_retries(self, mock_session_class, mock_session):
+        """Test that no adapter is mounted when retries is None."""
+        VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+        )
+        mock_session.mount.assert_not_called()
 
 
 class TestVaultClientIntegrationWithAuthenticators:
@@ -179,6 +287,47 @@ class TestVaultClientMakeRequest:
         expected_url = "https://vault.example.com:8200/some/path"
         client.session.request.assert_called_once_with("GET", expected_url)
 
+    def test_make_request_with_timeout(self, mock_session_class, mock_session):
+        """Test _make_request() injects timeout when set on client."""
+        client = VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+            timeout=30,
+        )
+        response = MagicMock()
+        mock_session.request = MagicMock()
+        mock_session.request.return_value = response
+        client._make_request('GET', 'some/path')
+        expected_url = 'https://vault.example.com:8200/some/path'
+        client.session.request.assert_called_once_with('GET', expected_url, timeout=30)
+
+    def test_make_request_without_timeout(self, mock_session_class, mock_session):
+        """Test _make_request() does not inject timeout when not set."""
+        client = VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+        )
+        response = MagicMock()
+        mock_session.request = MagicMock()
+        mock_session.request.return_value = response
+        client._make_request('GET', 'some/path')
+        expected_url = 'https://vault.example.com:8200/some/path'
+        client.session.request.assert_called_once_with('GET', expected_url)
+
+    def test_make_request_explicit_timeout_not_overridden(self, mock_session_class, mock_session):
+        """Test that explicit per-call timeout is not overridden by client timeout."""
+        client = VaultClient(
+            vault_address='https://vault.example.com:8200',
+            vault_namespace='test-namespace',
+            timeout=30,
+        )
+        response = MagicMock()
+        mock_session.request = MagicMock()
+        mock_session.request.return_value = response
+        client._make_request('GET', 'some/path', timeout=60)
+        expected_url = 'https://vault.example.com:8200/some/path'
+        client.session.request.assert_called_once_with('GET', expected_url, timeout=60)
+
     @pytest.mark.parametrize(
         "status_code,expected_exception",
         [
@@ -224,3 +373,41 @@ def test_read_proxies(proxies, expected):
         regex_message = r"Unexpected proxy key 'http2', should be one of \['http', 'https'\]"
         with pytest.raises(VaultConfigurationError, match=regex_message):
             VaultClient.read_proxies(proxies)
+
+
+class TestBuildRetry:
+    """Test VaultClient._build_retry() static method."""
+
+    def test_build_retry_with_int(self):
+        """Test _build_retry with integer input."""
+        with patch(MOCK_RETRY) as mock_retry_cls:
+            VaultClient._build_retry(3)
+            mock_retry_cls.assert_called_once_with(total=3)
+
+    def test_build_retry_with_dict(self):
+        """Test _build_retry with dict input."""
+        with patch(MOCK_RETRY) as mock_retry_cls:
+            VaultClient._build_retry({'total': 3, 'backoff_factor': 0.5})
+            mock_retry_cls.assert_called_once_with(total=3, backoff_factor=0.5)
+
+    def test_build_retry_with_string_int(self):
+        """Test _build_retry with string integer input."""
+        with patch(MOCK_RETRY) as mock_retry_cls:
+            VaultClient._build_retry('3')
+            mock_retry_cls.assert_called_once_with(total=3)
+
+    def test_build_retry_with_string_json(self):
+        """Test _build_retry with JSON string input."""
+        with patch(MOCK_RETRY) as mock_retry_cls:
+            VaultClient._build_retry('{"total": 5}')
+            mock_retry_cls.assert_called_once_with(total=5)
+
+    def test_build_retry_with_invalid_string(self):
+        """Test _build_retry with invalid string raises error."""
+        with pytest.raises(VaultConfigurationError, match='retries must be an integer or a JSON dictionary string'):
+            VaultClient._build_retry('invalid')
+
+    def test_build_retry_with_invalid_type(self):
+        """Test _build_retry with unsupported type raises error."""
+        with pytest.raises(VaultConfigurationError, match='retries must be an integer or a dictionary'):
+            VaultClient._build_retry([1, 2, 3])


### PR DESCRIPTION
##### SUMMARY
Adds `timeout` and `retries` parameters to all modules and lookup plugins for configurable request timeouts and automatic retry logic when communicating with Vault API.

Also adds `connection_name` parameter alias to `database_role` module for consistency with `database_connection` module.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
vault_client, authentication, database_role

##### ADDITIONAL INFORMATION
This change enhances the collection's reliability by allowing users to configure timeout values and automatic retry behavior for Vault API requests.

Assisted-by: Claude Sonnet 4.5