### PR TITLE
ci: add 48-hour timeout to integration tests job

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,6 +12,7 @@ jobs:
   run-integration-tests:
     name: Run Integration Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 2880
     # If this Pull Request is coming from a fork, use the 'vault-integration' environment. Otherwise,  don't use any environment at all.
     environment: ${{ github.event.pull_request.head.repo.fork && 'vault-integration' || '' }}
     strategy:


### PR DESCRIPTION
##### SUMMARY
Add a 48-hour timeout to the integration tests job to ensure deployment approvals automatically cancel if not approved within that timeframe.

##### ISSUE TYPE
CI/CD Pull Request

##### COMPONENT NAME
.github/workflows/integration.yml

##### ADDITIONAL INFORMATION
This prevents integration test jobs from waiting indefinitely for environment approvals.

Assisted-by: Claude Sonnet 4.5