### PR TITLE
ACA-6601: Deprecate namespace default value change from admin to root

### DIFF
--- a/changelogs/fragments/deprecate-namespace-admin-default.yml
+++ b/changelogs/fragments/deprecate-namespace-admin-default.yml
@@ -1,4 +1,5 @@
 ---
 deprecated_features:
   - All modules and lookup plugins - the default value for the ``namespace`` parameter will change from ``admin`` to ``root`` in version 2.0.0.
-    Users should explicitly set ``namespace`` to either ``admin`` (to preserve current behavior) or ``root`` (to adopt the new default early).
+    Users should explicitly set ``namespace`` to either ``admin`` (to preserve current behavior) or ``root`` (to adopt the new default early)
+    (https://github.com/ansible-collections/hashicorp.vault/pull/141).

--- a/changelogs/fragments/deprecate-namespace-admin-default.yml
+++ b/changelogs/fragments/deprecate-namespace-admin-default.yml
@@ -1,0 +1,4 @@
+---
+deprecated_features:
+  - All modules and lookup plugins - the default value for the ``namespace`` parameter will change from ``admin`` to ``root`` in version 2.0.0.
+    Users should explicitly set ``namespace`` to either ``admin`` (to preserve current behavior) or ``root`` (to adopt the new default early).

--- a/plugins/module_utils/vault_auth_utils.py
+++ b/plugins/module_utils/vault_auth_utils.py
@@ -96,7 +96,8 @@ def get_authenticated_client(module):
     if vault_namespace == "admin":
         module.deprecate(
             "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
-            "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) or 'root' (to adopt the new default early).",
+            "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) "
+            "or 'root' (to adopt the new default early).",
             version="2.0.0",
             collection_name="hashicorp.vault",
         )

--- a/plugins/module_utils/vault_auth_utils.py
+++ b/plugins/module_utils/vault_auth_utils.py
@@ -91,6 +91,16 @@ def get_authenticated_client(module):
     from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import VaultClient
 
     vault_namespace = module.params["namespace"]
+
+    # Deprecation warning for namespace default value change
+    if vault_namespace == "admin":
+        module.deprecate(
+            "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
+            "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) or 'root' (to adopt the new default early).",
+            version="2.0.0",
+            collection_name="hashicorp.vault",
+        )
+
     vault_address = module.params["url"]
     ca_cert = module.params["ca_cert"]
     tls_skip_verify = module.params["tls_skip_verify"]

--- a/plugins/module_utils/vault_auth_utils.py
+++ b/plugins/module_utils/vault_auth_utils.py
@@ -95,9 +95,8 @@ def get_authenticated_client(module):
     # Deprecation warning for namespace default value change
     if vault_namespace == "admin":
         module.deprecate(
-            "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
-            "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) "
-            "or 'root' (to adopt the new default early).",
+            "The default value for 'namespace' will change from 'admin' to 'root' in version 2.0.0. "
+            "To avoid potential issues, explicitly set 'namespace' in your playbooks if you rely on the current default.",
             version="2.0.0",
             collection_name="hashicorp.vault",
         )

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -54,6 +54,16 @@ class VaultLookupBase(LookupBase):
         self.set_options(var_options=variables, direct=kwargs)
 
         vault_namespace = self.get_option("namespace")
+
+        # Deprecation warning for namespace default value change
+        if vault_namespace == "admin":
+            self.display.deprecated(
+                "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
+                "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) or 'root' (to adopt the new default early).",
+                version="2.0.0",
+                collection_name="hashicorp.vault",
+            )
+
         vault_address = self.get_option("url")
         ca_cert = self.get_option("ca_cert")
         tls_skip_verify = self.get_option("tls_skip_verify")

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -59,7 +59,8 @@ class VaultLookupBase(LookupBase):
         if vault_namespace == "admin":
             self._display.deprecated(
                 "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
-                "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) or 'root' (to adopt the new default early).",
+                "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) "
+                "or 'root' (to adopt the new default early).",
                 version="2.0.0",
                 collection_name="hashicorp.vault",
             )

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -57,7 +57,7 @@ class VaultLookupBase(LookupBase):
 
         # Deprecation warning for namespace default value change
         if vault_namespace == "admin":
-            self.display.deprecated(
+            self._display.deprecated(
                 "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
                 "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) or 'root' (to adopt the new default early).",
                 version="2.0.0",

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -58,9 +58,8 @@ class VaultLookupBase(LookupBase):
         # Deprecation warning for namespace default value change
         if vault_namespace == "admin":
             self._display.deprecated(
-                "The default value for the 'namespace' parameter will change from 'admin' to 'root' in version 2.0.0. "
-                "To prepare for this change, explicitly set 'namespace' to either 'admin' (to keep current behavior) "
-                "or 'root' (to adopt the new default early).",
+                "The default value for 'namespace' will change from 'admin' to 'root' in version 2.0.0. "
+                "To avoid potential issues, explicitly set 'namespace' in your playbooks if you rely on the current default.",
                 version="2.0.0",
                 collection_name="hashicorp.vault",
             )


### PR DESCRIPTION
##### SUMMARY
Adds deprecation warnings to all modules and lookup plugins when `namespace='admin'` is used. The default value for the `namespace` parameter will change from `'admin'` to `'root'` in version 2.0.0 to align with HashiCorp Vault's standard root namespace.

This PR prepares users for the breaking change by:
- Adding deprecation warnings in `vault_auth_utils.py` for modules
- Adding deprecation warnings in `base.py` for lookup plugins
- Creating a changelog fragment documenting the deprecation

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
All modules and lookup plugins

Assisted-by: Claude Sonnet 4.5