### PR TITLE
ci: update GitHub Actions to latest versions with SHA pinning

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -21,14 +21,14 @@ jobs:
         ansible-version:
           - milestone
         python-version:
-          - "3.12"
+          - "3.13"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
##### SUMMARY
Updates GitHub Actions to their latest versions with SHA pinning for improved security:
- actions/checkout: v4 → v7.0.0
- actions/setup-python: v5 → v6.3.0

Also updates the python version for milestone testing from 3.12 to 3.13.

##### ISSUE TYPE
CI/CD Pull Request

##### COMPONENT NAME
.github/workflows/integration.yml

##### ADDITIONAL INFORMATION
SHA pinning provides better security by preventing tag-based attacks while the version comments maintain readability.

Assisted-by: Claude Sonnet 4.5