### PR TITLE
Kubernetes token

### DIFF
--- a/changelogs/fragments/add-kubernetes-token-module.yml
+++ b/changelogs/fragments/add-kubernetes-token-module.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - modules - add the new `kubernetes_token` module to generate Kubernetes bearer tokens from the Vault Kubernetes secrets engine.
+  - modules - add the new `kubernetes_token` module to generate Kubernetes bearer tokens from the Vault Kubernetes secrets engine. This module enables automated retrieval of short-lived Kubernetes service account tokens for secure, dynamic authentication to Kubernetes clusters managed by Vault.

--- a/changelogs/fragments/add-kubernetes-token-module.yml
+++ b/changelogs/fragments/add-kubernetes-token-module.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - modules - add the new `kubernetes_token` module to generate Kubernetes bearer tokens from the Vault Kubernetes secrets engine.

--- a/docs/hashicorp.vault.kubernetes_token_module.rst
+++ b/docs/hashicorp.vault.kubernetes_token_module.rst
@@ -1,0 +1,282 @@
+.. _hashicorp.vault.kubernetes_token_module:
+
+
+********************************
+hashicorp.vault.kubernetes_token
+********************************
+
+**Generate a Kubernetes bearer token from the Kubernetes secrets engine.**
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+- Generates a short-lived Kubernetes bearer token for a Vault Kubernetes secrets engine role.
+- Each invocation generates a new token with a unique lease.
+- Supports Vault token and AppRole authentication through the standard collection authentication options.
+
+
+Requirements
+------------
+
+The below requirements are needed on the host that executes this module.
+
+- requests
+
+
+Parameters
+----------
+
+.. raw:: html
+
+   <table>
+     <thead>
+       <tr>
+         <th>Parameter</th>
+         <th>Choices/Defaults</th>
+         <th>Comments</th>
+       </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <td><b>audience</b></td>
+         <td></td>
+         <td>
+           <div>Audience claim to request for the generated Kubernetes token.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>auth_method</b></td>
+         <td>
+           <ul>
+             <li>Choices:
+               <ul>
+                 <li><code>token</code></li>
+                 <li><code>approle</code></li>
+               </ul>
+             </li>
+             <li>Default: <code>token</code></li>
+           </ul>
+         </td>
+         <td>
+           <div>Authentication method to use.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>ca_cert</b></td>
+         <td></td>
+         <td>
+           <div>The path to a PEM-encoded CA certificate file to use for TLS verification.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>kubernetes_mount_path</b></td>
+         <td><div>Default: <code>kubernetes</code></div></td>
+         <td>
+           <div>Kubernetes secrets engine mount path.</div>
+           <div>aliases: path</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>kubernetes_namespace</b></td>
+         <td></td>
+         <td>
+           <div>Kubernetes namespace to request credentials for.</div>
+           <div>When omitted, Vault uses the role or engine defaults.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>name</b></td>
+         <td></td>
+         <td>
+           <div>The name of the Kubernetes role to generate a token for.</div>
+           <div>aliases: role</div>
+           <div>type: str</div>
+           <div>required: true</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>namespace</b></td>
+         <td><div>Default: <code>admin</code></div></td>
+         <td>
+           <div>Vault namespace.</div>
+           <div>aliases: vault_namespace</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>proxies</b></td>
+         <td></td>
+         <td>
+           <div>URL(s) to the proxies used to access the Vault service.</div>
+           <div>type: raw</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>retries</b></td>
+         <td></td>
+         <td>
+           <div>Number of retries to perform on failed requests, or a dictionary of retry configuration.</div>
+           <div>type: raw</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>role_id</b></td>
+         <td></td>
+         <td>
+           <div>Role ID for AppRole authentication.</div>
+           <div>aliases: approle_role_id</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>secret_id</b></td>
+         <td></td>
+         <td>
+           <div>Secret ID for AppRole authentication.</div>
+           <div>aliases: approle_secret_id</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>timeout</b></td>
+         <td></td>
+         <td>
+           <div>Timeout for Vault API requests in seconds.</div>
+           <div>type: int</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>tls_skip_verify</b></td>
+         <td><div>Default: <code>false</code></div></td>
+         <td>
+           <div>Controls whether the module verifies the TLS certificate presented by the Vault server.</div>
+           <div>type: bool</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>token</b></td>
+         <td></td>
+         <td>
+           <div>Vault token for authentication.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>ttl</b></td>
+         <td></td>
+         <td>
+           <div>Requested TTL for the generated token.</div>
+           <div>The effective TTL is still subject to Vault role and mount limits.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>url</b></td>
+         <td></td>
+         <td>
+           <div>Vault server URL.</div>
+           <div>aliases: vault_address</div>
+           <div>type: str</div>
+           <div>required: true</div>
+         </td>
+       </tr>
+       <tr>
+         <td><b>vault_approle_path</b></td>
+         <td><div>Default: <code>approle</code></div></td>
+         <td>
+           <div>AppRole auth method mount path.</div>
+           <div>type: str</div>
+         </td>
+       </tr>
+     </tbody>
+   </table>
+
+
+Notes
+-----
+
+- For security reasons, this module should be used with ``no_log=true`` and ``register``.
+- This module is not idempotent; each call generates a new token with a new lease.
+- This module returns a Kubernetes bearer token from the Vault Kubernetes secrets engine, not a Vault auth token.
+
+
+Examples
+--------
+
+.. code-block:: yaml+jinja
+
+    - name: Generate a Kubernetes token using Vault token authentication
+      hashicorp.vault.kubernetes_token:
+        url: https://vault.example.com:8200
+        token: "{{ vault_token }}"
+        kubernetes_mount_path: myOcpCluster
+        name: superuser
+        audience: openshift
+        ttl: 1h
+        kubernetes_namespace: vault-test
+        namespace: root
+      no_log: true
+      register: result
+
+    - name: Generate a Kubernetes token using AppRole authentication
+      hashicorp.vault.kubernetes_token:
+        url: https://vault.example.com:8200
+        auth_method: approle
+        role_id: "{{ vault_role_id }}"
+        secret_id: "{{ vault_secret_id }}"
+        kubernetes_mount_path: myOcpCluster
+        name: superuser
+        kubernetes_namespace: kube-system
+        ttl: 1h
+      no_log: true
+      register: result
+
+    - name: Use the generated bearer token
+      ansible.builtin.debug:
+        msg: "{{ result.kubernetes_token.service_account_token }}"
+      no_log: true
+
+
+Return Values
+-------------
+
+.. raw:: html
+
+   <table>
+     <thead>
+       <tr>
+         <th>Key</th>
+         <th>Returned</th>
+         <th>Description</th>
+       </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <td><b>kubernetes_token</b></td>
+         <td>always</td>
+         <td>
+           <div>The generated Kubernetes token data and lease information.</div>
+           <div>type: dict</div>
+           <div>sample:</div>
+           <pre>{
+    "service_account_name": "vault-secrets-superuser",
+    "service_account_namespace": "kube-system",
+    "service_account_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9...",
+    "lease_id": "kubernetes/creds/superuser/abc123",
+    "lease_duration": 3600,
+    "renewable": false
+        }</pre>
+         </td>
+       </tr>
+     </tbody>
+   </table>

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -20,6 +20,7 @@ action_groups:
     - kv1_secret_info
     - kv2_secret
     - kv2_secret_info
+    - kubernetes_token
     - pki_certificate
     - pki_certificate_info
     - vault_namespace

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -258,7 +258,10 @@ class VaultClient:
         """
 
         url = f"{self.vault_address}/{path}"
-        logger.debug("Making %s request to %s with params: %s", method, url, kwargs.get("params"))
+        logger.debug("Making %s request to %s", method, url)
+        logger.debug("Request params: %s", kwargs.get("params"))
+        logger.debug("Request json body: %s", kwargs.get("json"))
+        logger.debug("Request headers: %s", dict(self.session.headers))
         if self.timeout is not None and 'timeout' not in kwargs:
             kwargs['timeout'] = self.timeout
         try:

--- a/plugins/module_utils/vault_client.py
+++ b/plugins/module_utils/vault_client.py
@@ -261,7 +261,10 @@ class VaultClient:
         logger.debug("Making %s request to %s", method, url)
         logger.debug("Request params: %s", kwargs.get("params"))
         logger.debug("Request json body: %s", kwargs.get("json"))
-        logger.debug("Request headers: %s", dict(self.session.headers))
+        try:
+            logger.debug("Request headers: %s", dict(self.session.headers))
+        except (TypeError, AttributeError):
+            logger.debug("Request headers: %s", self.session.headers)
         if self.timeout is not None and 'timeout' not in kwargs:
             kwargs['timeout'] = self.timeout
         try:

--- a/plugins/module_utils/vault_kubernetes.py
+++ b/plugins/module_utils/vault_kubernetes.py
@@ -9,6 +9,8 @@ __metaclass__ = type
 
 from typing import Any, Dict, Optional
 
+__all__ = ['VaultKubernetes']
+
 
 class VaultKubernetes:
     """
@@ -25,7 +27,7 @@ class VaultKubernetes:
                 Defaults to "kubernetes".
         """
         self._client = client
-        self._mount_path = (mount_path or "kubernetes").strip().strip("/")
+        self._mount_path = (mount_path or "kubernetes").strip("/").strip()
 
     def generate_token(
         self,
@@ -47,6 +49,9 @@ class VaultKubernetes:
         Returns:
             Dict[str, Any]: The generated token data merged with lease metadata.
 
+        Raises:
+            ValueError: If name is empty or None.
+
         Example:
             token = kube.generate_token(
                 "superuser",
@@ -55,6 +60,9 @@ class VaultKubernetes:
                 audience="openshift",
             )
         """
+        if not name or not name.strip():
+            raise ValueError("Role name cannot be empty")
+
         path = f"v1/{self._mount_path}/creds/{name}"
         params = {
             "kubernetes_namespace": kubernetes_namespace,

--- a/plugins/module_utils/vault_kubernetes.py
+++ b/plugins/module_utils/vault_kubernetes.py
@@ -63,7 +63,12 @@ class VaultKubernetes:
         }
         payload = {key: value for key, value in params.items() if value is not None}
 
-        response_data = self._client._make_request("POST", path, json=payload)
+        # Only send json parameter if we have data to send
+        # Some Vault endpoints reject empty JSON bodies
+        if payload:
+            response_data = self._client._make_request("POST", path, json=payload)
+        else:
+            response_data = self._client._make_request("POST", path)
         out = dict(response_data.get("data", {}))
         for key in ("lease_id", "lease_duration", "renewable"):
             if key in response_data:

--- a/plugins/module_utils/vault_kubernetes.py
+++ b/plugins/module_utils/vault_kubernetes.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from typing import Any, Dict, Optional
+
+
+class VaultKubernetes:
+    """
+    Client for interacting with Vault's Kubernetes secrets engine.
+    """
+
+    def __init__(self, client, mount_path="kubernetes"):
+        """
+        Initialize the Kubernetes secrets engine client.
+
+        Args:
+            client (VaultClient): An authenticated Vault client.
+            mount_path (str): The mount path of the Kubernetes secrets engine.
+                Defaults to "kubernetes".
+        """
+        self._client = client
+        self._mount_path = (mount_path or "kubernetes").strip().strip("/")
+
+    def generate_token(
+        self,
+        name: str,
+        kubernetes_namespace: Optional[str] = None,
+        ttl: Optional[str] = None,
+        audience: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """
+        Generate a Kubernetes service account token from a Vault Kubernetes role.
+
+        Args:
+            name (str): The name of the Vault Kubernetes role.
+            kubernetes_namespace (str, optional): Kubernetes namespace to request
+                credentials for.
+            ttl (str, optional): Requested TTL for the generated token.
+            audience (str, optional): Requested audience for the generated token.
+
+        Returns:
+            Dict[str, Any]: The generated token data merged with lease metadata.
+
+        Example:
+            token = kube.generate_token(
+                "superuser",
+                kubernetes_namespace="kube-system",
+                ttl="1h",
+                audience="openshift",
+            )
+        """
+        path = f"v1/{self._mount_path}/creds/{name}"
+        params = {
+            "kubernetes_namespace": kubernetes_namespace,
+            "ttl": ttl,
+            "audience": audience,
+        }
+        payload = {key: value for key, value in params.items() if value is not None}
+
+        response_data = self._client._make_request("POST", path, json=payload)
+        out = dict(response_data.get("data", {}))
+        for key in ("lease_id", "lease_duration", "renewable"):
+            if key in response_data:
+                out[key] = response_data[key]
+        return out

--- a/plugins/module_utils/vault_secrets.py
+++ b/plugins/module_utils/vault_secrets.py
@@ -25,8 +25,15 @@ class Secrets:
         pki: PKI (Public Key Infrastructure) secrets engine
     """
 
-    def __init__(self, client):
-        self.kubernetes = VaultKubernetes(client)
+    def __init__(self, client, kubernetes_mount_path="kubernetes"):
+        """
+        Initialize the Secrets container.
+
+        Args:
+            client: An authenticated Vault client.
+            kubernetes_mount_path: Mount path for Kubernetes secrets engine (default: "kubernetes").
+        """
+        self.kubernetes = VaultKubernetes(client, mount_path=kubernetes_mount_path)
         self.kv2 = VaultKv2Secrets(client)
         self.kv1 = VaultKv1Secrets(client)
         self.pki = VaultPki(client)

--- a/plugins/module_utils/vault_secrets.py
+++ b/plugins/module_utils/vault_secrets.py
@@ -7,6 +7,7 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_kubernetes import VaultKubernetes
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_kv1_secrets import VaultKv1Secrets
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_kv2_secrets import VaultKv2Secrets
 from ansible_collections.hashicorp.vault.plugins.module_utils.vault_pki import VaultPki
@@ -18,12 +19,14 @@ class Secrets:
     """A container class for different secrets engine clients.
 
     Attributes:
+        kubernetes: Kubernetes secrets engine
         kv1: Key-Value version 1 secrets engine
         kv2: Key-Value version 2 secrets engine
         pki: PKI (Public Key Infrastructure) secrets engine
     """
 
     def __init__(self, client):
+        self.kubernetes = VaultKubernetes(client)
         self.kv2 = VaultKv2Secrets(client)
         self.kv1 = VaultKv1Secrets(client)
         self.pki = VaultPki(client)

--- a/plugins/modules/kubernetes_token.py
+++ b/plugins/modules/kubernetes_token.py
@@ -120,13 +120,13 @@ def main() -> None:
     """Entry point for module execution"""
     argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
     argument_spec.update(
-        dict(
-            kubernetes_mount_path=dict(type="str", default="kubernetes", aliases=["path"]),
-            name=dict(type="str", required=True, aliases=["role"]),
-            kubernetes_namespace=dict(type="str"),
-            ttl=dict(type="str"),
-            audience=dict(type="str"),
-        )
+        {
+            "kubernetes_mount_path": {"type": "str", "default": "kubernetes", "aliases": ["path"]},
+            "name": {"type": "str", "required": True, "aliases": ["role"]},
+            "kubernetes_namespace": {"type": "str"},
+            "ttl": {"type": "str"},
+            "audience": {"type": "str"},
+        }
     )
     module = AnsibleModule(
         argument_spec=argument_spec,

--- a/plugins/modules/kubernetes_token.py
+++ b/plugins/modules/kubernetes_token.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, annotations, division, print_function
+
+DOCUMENTATION = """
+---
+module: kubernetes_token
+author: Joshua Beha (@Joshua-Beha)
+version_added: "1.3.0"
+short_description: Generate a Kubernetes bearer token from the Kubernetes secrets engine.
+description:
+    - Generates a short-lived Kubernetes bearer token for a Vault Kubernetes secrets engine role.
+    - Each invocation generates a new token with a unique lease.
+    - Supports Vault token and AppRole authentication through the standard collection authentication options.
+options:
+  kubernetes_mount_path:
+    description: Kubernetes secrets engine mount path.
+    type: str
+    default: kubernetes
+    aliases: [path]
+  name:
+    description: The name of the Kubernetes role to generate a token for.
+    required: true
+    type: str
+    aliases: [role]
+  kubernetes_namespace:
+    description:
+      - Kubernetes namespace to request credentials for.
+      - When omitted, Vault uses the role or engine defaults.
+    type: str
+  ttl:
+    description:
+      - Requested TTL for the generated token.
+      - The effective TTL is still subject to Vault role and mount limits.
+    type: str
+  audience:
+    description:
+      - Audience claim to request for the generated Kubernetes token.
+    type: str
+extends_documentation_fragment:
+  - hashicorp.vault.vault_auth.modules
+notes:
+  - For security reasons, this module should be used with B(no_log=true) and C(register).
+  - This module is NOT idempotent - each call generates a new token with a new lease.
+  - This module returns a Kubernetes bearer token from the Vault Kubernetes secrets engine, not a Vault auth token.
+"""
+
+EXAMPLES = """
+- name: Generate a Kubernetes token using Vault token authentication
+  hashicorp.vault.kubernetes_token:
+    url: https://vault.example.com:8200
+    token: "{{ vault_token }}"
+    kubernetes_mount_path: myOcpCluster
+    name: superuser
+    audience: openshift
+    ttl: 1h
+    kubernetes_namespace: vault-test
+    namespace: root
+  no_log: true
+  register: result
+
+- name: Generate a Kubernetes token using AppRole authentication
+  hashicorp.vault.kubernetes_token:
+    url: https://vault.example.com:8200
+    auth_method: approle
+    role_id: "{{ vault_role_id }}"
+    secret_id: "{{ vault_secret_id }}"
+    kubernetes_mount_path: myOcpCluster
+    name: superuser
+    kubernetes_namespace: kube-system
+    ttl: 1h
+  no_log: true
+  register: result
+
+- name: Use the generated bearer token
+  ansible.builtin.debug:
+    msg: "{{ result.kubernetes_token.service_account_token }}"
+  no_log: true
+"""
+
+RETURN = """
+kubernetes_token:
+  description: The generated Kubernetes token data and lease information.
+  type: dict
+  returned: always
+  sample:
+    {
+        "service_account_name": "vault-secrets-superuser",
+        "service_account_namespace": "kube-system",
+        "service_account_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9...",
+        "lease_id": "kubernetes/creds/superuser/abc123",
+        "lease_duration": 3600,
+        "renewable": false
+    }
+"""
+
+
+__metaclass__ = type  # pylint: disable=C0103
+
+import copy
+
+from ansible.module_utils.basic import AnsibleModule  # type: ignore
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.args_common import AUTH_ARG_SPEC
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_auth_utils import (
+    get_authenticated_client,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+    VaultPermissionError,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_kubernetes import (
+    VaultKubernetes,
+)
+
+
+def main() -> None:
+    """Entry point for module execution"""
+    argument_spec = copy.deepcopy(AUTH_ARG_SPEC)
+    argument_spec.update(
+        dict(
+            kubernetes_mount_path=dict(type="str", default="kubernetes", aliases=["path"]),
+            name=dict(type="str", required=True, aliases=["role"]),
+            kubernetes_namespace=dict(type="str"),
+            ttl=dict(type="str"),
+            audience=dict(type="str"),
+        )
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        supports_check_mode=False,
+    )
+
+    client = get_authenticated_client(module)
+
+    mount_path = module.params.get("kubernetes_mount_path")
+    name = module.params.get("name")
+
+    try:
+        kubernetes_client = VaultKubernetes(client, mount_path=mount_path)
+
+        data = kubernetes_client.generate_token(
+            name=name,
+            kubernetes_namespace=module.params.get("kubernetes_namespace"),
+            ttl=module.params.get("ttl"),
+            audience=module.params.get("audience"),
+        )
+
+        module.exit_json(changed=True, kubernetes_token=data)
+
+    except VaultPermissionError as e:
+        module.fail_json(msg=f"Permission denied: {e}")
+    except VaultApiError as e:
+        module.fail_json(msg=f"Vault API error: {e}")
+    except Exception as e:
+        module.fail_json(msg=f"Operation failed: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/kubernetes_token.py
+++ b/plugins/modules/kubernetes_token.py
@@ -5,6 +5,8 @@
 
 from __future__ import absolute_import, annotations, division, print_function
 
+__metaclass__ = type  # pylint: disable=C0103
+
 DOCUMENTATION = """
 ---
 module: kubernetes_token
@@ -43,7 +45,7 @@ options:
 extends_documentation_fragment:
   - hashicorp.vault.vault_auth.modules
 notes:
-  - For security reasons, this module should be used with B(no_log=true) and C(register).
+  - This module should be used with B(no_log=true) and C(register) to prevent sensitive token data from being logged to console or log files, as the generated Kubernetes bearer token provides authentication credentials.
   - This module is NOT idempotent - each call generates a new token with a new lease.
   - This module returns a Kubernetes bearer token from the Vault Kubernetes secrets engine, not a Vault auth token.
 """
@@ -97,9 +99,6 @@ kubernetes_token:
     }
 """
 
-
-__metaclass__ = type  # pylint: disable=C0103
-
 import copy
 
 from ansible.module_utils.basic import AnsibleModule  # type: ignore
@@ -131,8 +130,11 @@ def main() -> None:
     )
     module = AnsibleModule(
         argument_spec=argument_spec,
-        supports_check_mode=False,
+        supports_check_mode=True,
     )
+
+    if module.check_mode:
+        module.exit_json(changed=True, kubernetes_token={})
 
     client = get_authenticated_client(module)
 

--- a/plugins/modules/kubernetes_token.py
+++ b/plugins/modules/kubernetes_token.py
@@ -11,7 +11,7 @@ DOCUMENTATION = """
 ---
 module: kubernetes_token
 author: Joshua Beha (@Joshua-Beha)
-version_added: "1.3.0"
+version_added: "1.4.0"
 short_description: Generate a Kubernetes bearer token from the Kubernetes secrets engine.
 description:
     - Generates a short-lived Kubernetes bearer token for a Vault Kubernetes secrets engine role.
@@ -45,7 +45,9 @@ options:
 extends_documentation_fragment:
   - hashicorp.vault.vault_auth.modules
 notes:
-  - This module should be used with B(no_log=true) and C(register) to prevent sensitive token data from being logged to console or log files, as the generated Kubernetes bearer token provides authentication credentials.
+  - The C(service_account_token) field in the return value is a sensitive bearer token.
+    Always use B(no_log=true) at the task level to prevent it from appearing in Ansible
+    output, logs, and callback plugins.
   - This module is NOT idempotent - each call generates a new token with a new lease.
   - This module returns a Kubernetes bearer token from the Vault Kubernetes secrets engine, not a Vault auth token.
 """
@@ -88,6 +90,30 @@ kubernetes_token:
   description: The generated Kubernetes token data and lease information.
   type: dict
   returned: always
+  no_log: true
+  contains:
+    service_account_token:
+      description:
+        - The Kubernetes bearer token.
+        - This value is sensitive. Always use B(no_log=true) at the task level to
+          prevent exposure in Ansible output and logs.
+      type: str
+      no_log: true
+    service_account_name:
+      description: The name of the service account the token was issued for.
+      type: str
+    service_account_namespace:
+      description: The Kubernetes namespace of the service account.
+      type: str
+    lease_id:
+      description: The Vault lease ID for this token.
+      type: str
+    lease_duration:
+      description: The duration of the lease in seconds.
+      type: int
+    renewable:
+      description: Whether the lease can be renewed.
+      type: bool
   sample:
     {
         "service_account_name": "vault-secrets-superuser",

--- a/tests/integration/integration_config.yml.template
+++ b/tests/integration/integration_config.yml.template
@@ -1,6 +1,7 @@
 ---
 vault_url: {{ lookup('env', 'VAULT_ADDR') }}
 vault_namespace: {{ lookup('env', 'VAULT_NAMESPACE') }}
+vault_root_token: {{ lookup('env', 'VAULT_ROOT_TOKEN') }}
 vault_approle_role_id: {{ lookup('env', 'VAULT_APPROLE_ROLE_ID') }}
 vault_approle_secret_id: {{ lookup('env', 'VAULT_APPROLE_SECRET_ID') }}
 vault_resource_suffix: '{{ lookup('password', '/dev/null', chars='ascii_letters,digits', length=8) }}'

--- a/tests/integration/targets/kubernetes_token/aliases
+++ b/tests/integration/targets/kubernetes_token/aliases
@@ -1,0 +1,1 @@
+kubernetes_token

--- a/tests/integration/targets/kubernetes_token/defaults/main.yml
+++ b/tests/integration/targets/kubernetes_token/defaults/main.yml
@@ -6,3 +6,4 @@ ansible_test_kubernetes_role_name: "superuser"
 ansible_test_kubernetes_namespace: "kube-system"
 ansible_test_kubernetes_audience: ""
 ansible_test_kubernetes_ttl: "1h"
+ansible_test_kubernetes_validate_certs: false

--- a/tests/integration/targets/kubernetes_token/defaults/main.yml
+++ b/tests/integration/targets/kubernetes_token/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+ansible_test_vault_mount_path: "approle-integration-tests"
+ansible_test_kubernetes_fixture_enabled: false
+ansible_test_kubernetes_mount_path: "kubernetes"
+ansible_test_kubernetes_role_name: "superuser"
+ansible_test_kubernetes_namespace: "kube-system"
+ansible_test_kubernetes_audience: ""
+ansible_test_kubernetes_ttl: "1h"

--- a/tests/integration/targets/kubernetes_token/meta/main.yml
+++ b/tests/integration/targets/kubernetes_token/meta/main.yml
@@ -1,0 +1,2 @@
+---
+dependencies: []

--- a/tests/integration/targets/kubernetes_token/meta/main.yml
+++ b/tests/integration/targets/kubernetes_token/meta/main.yml
@@ -1,4 +1,4 @@
 ---
 dependencies:
-  - setup_auth_token
   - setup_vault_dev_with_kubernetes
+  - setup_auth_token

--- a/tests/integration/targets/kubernetes_token/meta/main.yml
+++ b/tests/integration/targets/kubernetes_token/meta/main.yml
@@ -1,2 +1,4 @@
 ---
-dependencies: []
+dependencies:
+  - setup_auth_token
+  - setup_vault_dev_with_kubernetes

--- a/tests/integration/targets/kubernetes_token/tasks/main.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/main.yml
@@ -25,6 +25,10 @@
 
     - name: Generate Kubernetes token using Vault token authentication
       hashicorp.vault.kubernetes_token:
+        url: "{{ vault_url }}"
+        namespace: "{{ vault_namespace }}"
+        auth_method: token
+        token: "{{ vault_token_from_setup_auth_token }}"
         kubernetes_mount_path: "{{ test_kubernetes_mount_path }}"
         name: "{{ test_kubernetes_role_name }}"
         kubernetes_namespace: "{{ test_kubernetes_namespace }}"
@@ -45,8 +49,30 @@
           - token_auth_result.kubernetes_token.renewable is defined
       when: ansible_test_kubernetes_fixture_enabled
 
+    - name: Validate token authentication result by calling Kubernetes API
+      ansible.builtin.include_tasks: validate_token.yml
+      vars:
+        token_result: "{{ token_auth_result }}"
+        test_name: "token auth"
+      when: ansible_test_kubernetes_fixture_enabled
+
+    - name: Delete ClusterRole created by first test to allow second test to succeed
+      ansible.builtin.command:
+        argv:
+          - "{{ ansible_test_kubectl_binary }}"
+          - --kubeconfig
+          - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+          - delete
+          - clusterrole
+          - "{{ test_kubernetes_role_name }}"
+          - --ignore-not-found
+      changed_when: true
+      when: ansible_test_kubernetes_fixture_enabled
+
     - name: Generate Kubernetes token using AppRole authentication
       hashicorp.vault.kubernetes_token:
+        url: "{{ vault_url }}"
+        namespace: "{{ vault_namespace }}"
         auth_method: approle
         role_id: "{{ vault_approle_role_id }}"
         secret_id: "{{ vault_approle_secret_id }}"
@@ -57,7 +83,7 @@
         audience: "{{ test_kubernetes_audience }}"
         ttl: "{{ test_kubernetes_ttl }}"
       register: approle_auth_result
-      no_log: true
+      # no_log: true
       when:
         - ansible_test_kubernetes_fixture_enabled
         - vault_approle_role_id is defined
@@ -72,6 +98,16 @@
           - approle_auth_result.kubernetes_token.lease_id is defined
           - approle_auth_result.kubernetes_token.lease_duration is defined
           - approle_auth_result.kubernetes_token.renewable is defined
+      when:
+        - ansible_test_kubernetes_fixture_enabled
+        - vault_approle_role_id is defined
+        - vault_approle_secret_id is defined
+
+    - name: Validate AppRole authentication result by calling Kubernetes API
+      ansible.builtin.include_tasks: validate_token.yml
+      vars:
+        token_result: "{{ approle_auth_result }}"
+        test_name: "AppRole auth"
       when:
         - ansible_test_kubernetes_fixture_enabled
         - vault_approle_role_id is defined

--- a/tests/integration/targets/kubernetes_token/tasks/main.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/main.yml
@@ -1,0 +1,78 @@
+---
+- name: Run kubernetes_token tests
+  module_defaults:
+    group/hashicorp.vault.vault:
+      url: "{{ vault_url }}"
+      namespace: "{{ vault_namespace }}"
+      auth_method: token
+      token: "{{ vault_token_from_setup_auth_token }}"
+      vault_approle_path: "{{ ansible_test_vault_mount_path }}"
+  vars:
+    test_kubernetes_mount_path: "{{ ansible_test_kubernetes_mount_path }}"
+    test_kubernetes_role_name: "{{ ansible_test_kubernetes_role_name }}"
+    test_kubernetes_namespace: "{{ ansible_test_kubernetes_namespace }}"
+    test_kubernetes_audience: "{{ ansible_test_kubernetes_audience }}"
+    test_kubernetes_ttl: "{{ ansible_test_kubernetes_ttl }}"
+  block:
+    - name: Skip integration test when Kubernetes secrets engine test fixture is not configured
+      ansible.builtin.debug:
+        msg:
+          - "Skipping kubernetes_token integration coverage."
+          - "This target requires a Vault environment with the Kubernetes secrets engine configured."
+          - "Expected fixture inputs include mount path {{ test_kubernetes_mount_path }} and role {{ test_kubernetes_role_name }}."
+      changed_when: false
+      when: not ansible_test_kubernetes_fixture_enabled
+
+    - name: Generate Kubernetes token using Vault token authentication
+      hashicorp.vault.kubernetes_token:
+        kubernetes_mount_path: "{{ test_kubernetes_mount_path }}"
+        name: "{{ test_kubernetes_role_name }}"
+        kubernetes_namespace: "{{ test_kubernetes_namespace }}"
+        audience: "{{ test_kubernetes_audience }}"
+        ttl: "{{ test_kubernetes_ttl }}"
+      register: token_auth_result
+      no_log: true
+      when: ansible_test_kubernetes_fixture_enabled
+
+    - name: Validate Kubernetes token generated using Vault token authentication
+      ansible.builtin.assert:
+        that:
+          - token_auth_result is changed
+          - token_auth_result.kubernetes_token is defined
+          - token_auth_result.kubernetes_token.service_account_token is defined
+          - token_auth_result.kubernetes_token.lease_id is defined
+          - token_auth_result.kubernetes_token.lease_duration is defined
+          - token_auth_result.kubernetes_token.renewable is defined
+      when: ansible_test_kubernetes_fixture_enabled
+
+    - name: Generate Kubernetes token using AppRole authentication
+      hashicorp.vault.kubernetes_token:
+        auth_method: approle
+        role_id: "{{ vault_approle_role_id }}"
+        secret_id: "{{ vault_approle_secret_id }}"
+        vault_approle_path: "{{ ansible_test_vault_mount_path }}"
+        kubernetes_mount_path: "{{ test_kubernetes_mount_path }}"
+        name: "{{ test_kubernetes_role_name }}"
+        kubernetes_namespace: "{{ test_kubernetes_namespace }}"
+        audience: "{{ test_kubernetes_audience }}"
+        ttl: "{{ test_kubernetes_ttl }}"
+      register: approle_auth_result
+      no_log: true
+      when:
+        - ansible_test_kubernetes_fixture_enabled
+        - vault_approle_role_id is defined
+        - vault_approle_secret_id is defined
+
+    - name: Validate Kubernetes token generated using AppRole authentication
+      ansible.builtin.assert:
+        that:
+          - approle_auth_result is changed
+          - approle_auth_result.kubernetes_token is defined
+          - approle_auth_result.kubernetes_token.service_account_token is defined
+          - approle_auth_result.kubernetes_token.lease_id is defined
+          - approle_auth_result.kubernetes_token.lease_duration is defined
+          - approle_auth_result.kubernetes_token.renewable is defined
+      when:
+        - ansible_test_kubernetes_fixture_enabled
+        - vault_approle_role_id is defined
+        - vault_approle_secret_id is defined

--- a/tests/integration/targets/kubernetes_token/tasks/main.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/main.yml
@@ -83,7 +83,7 @@
         audience: "{{ test_kubernetes_audience }}"
         ttl: "{{ test_kubernetes_ttl }}"
       register: approle_auth_result
-      # no_log: true
+      no_log: true
       when:
         - ansible_test_kubernetes_fixture_enabled
         - vault_approle_role_id is defined

--- a/tests/integration/targets/kubernetes_token/tasks/main.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/main.yml
@@ -47,6 +47,7 @@
           - token_auth_result.kubernetes_token.lease_id is defined
           - token_auth_result.kubernetes_token.lease_duration is defined
           - token_auth_result.kubernetes_token.renewable is defined
+      no_log: true
       when: ansible_test_kubernetes_fixture_enabled
 
     - name: Validate token authentication result by calling Kubernetes API
@@ -56,7 +57,7 @@
         test_name: "token auth"
       when: ansible_test_kubernetes_fixture_enabled
 
-    - name: Clean up ClusterRole from previous test to ensure test independence
+    - name: Clean up ClusterRole before AppRole test to ensure test independence
       ansible.builtin.command:
         argv:
           - "{{ ansible_test_kubectl_binary }}"
@@ -99,6 +100,7 @@
           - approle_auth_result.kubernetes_token.lease_id is defined
           - approle_auth_result.kubernetes_token.lease_duration is defined
           - approle_auth_result.kubernetes_token.renewable is defined
+      no_log: true
       when:
         - ansible_test_kubernetes_fixture_enabled
         - vault_approle_role_id is defined

--- a/tests/integration/targets/kubernetes_token/tasks/main.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/main.yml
@@ -56,7 +56,7 @@
         test_name: "token auth"
       when: ansible_test_kubernetes_fixture_enabled
 
-    - name: Delete ClusterRole created by first test to allow second test to succeed
+    - name: Clean up ClusterRole from previous test to ensure test independence
       ansible.builtin.command:
         argv:
           - "{{ ansible_test_kubectl_binary }}"
@@ -67,6 +67,7 @@
           - "{{ test_kubernetes_role_name }}"
           - --ignore-not-found
       changed_when: true
+      failed_when: false
       when: ansible_test_kubernetes_fixture_enabled
 
     - name: Generate Kubernetes token using AppRole authentication

--- a/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
@@ -22,5 +22,3 @@
       - pods_list_result.json.kind == "PodList"
     fail_msg: "{{ test_name }} generated Kubernetes token failed to access the API"
     success_msg: "{{ test_name }} generated Kubernetes token successfully accessed the API"
-
-# Made with Bob

--- a/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
@@ -3,6 +3,7 @@
 # Parameters:
 #   - token_result: The result from kubernetes_token module containing the token
 #   - test_name: A descriptive name for the test (e.g., "token auth" or "AppRole auth")
+#   - ansible_test_kubernetes_validate_certs: Whether to validate TLS certificates (default: false for test environments)
 
 - name: "Use {{ test_name }} generated token to list pods in {{ test_kubernetes_namespace }} namespace"
   ansible.builtin.uri:
@@ -10,9 +11,11 @@
     method: GET
     headers:
       Authorization: "Bearer {{ token_result.kubernetes_token.service_account_token }}"
-    validate_certs: false
+    validate_certs: "{{ ansible_test_kubernetes_validate_certs | default(false) }}"
     status_code: 200
   register: pods_list_result
+  # Note: validate_certs should be true in production environments.
+  # For local kind/minikube clusters with self-signed certificates, it may need to be false.
 
 - name: "Validate that {{ test_name }} token can access Kubernetes API"
   ansible.builtin.assert:

--- a/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
@@ -1,0 +1,26 @@
+---
+# Reusable task file to validate a generated Kubernetes token
+# Parameters:
+#   - token_result: The result from kubernetes_token module containing the token
+#   - test_name: A descriptive name for the test (e.g., "token auth" or "AppRole auth")
+
+- name: "Use {{ test_name }} generated token to list pods in {{ test_kubernetes_namespace }} namespace"
+  ansible.builtin.uri:
+    url: "{{ kubernetes_host.stdout }}/api/v1/namespaces/{{ test_kubernetes_namespace }}/pods"
+    method: GET
+    headers:
+      Authorization: "Bearer {{ token_result.kubernetes_token.service_account_token }}"
+    validate_certs: false
+    status_code: 200
+  register: pods_list_result
+
+- name: "Validate that {{ test_name }} token can access Kubernetes API"
+  ansible.builtin.assert:
+    that:
+      - pods_list_result.status == 200
+      - pods_list_result.json is defined
+      - pods_list_result.json.kind == "PodList"
+    fail_msg: "{{ test_name }} generated Kubernetes token failed to access the API"
+    success_msg: "{{ test_name }} generated Kubernetes token successfully accessed the API"
+
+# Made with Bob

--- a/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
+++ b/tests/integration/targets/kubernetes_token/tasks/validate_token.yml
@@ -14,8 +14,7 @@
     validate_certs: "{{ ansible_test_kubernetes_validate_certs | default(false) }}"
     status_code: 200
   register: pods_list_result
-  # Note: validate_certs should be true in production environments.
-  # For local kind/minikube clusters with self-signed certificates, it may need to be false.
+  no_log: true
 
 - name: "Validate that {{ test_name }} token can access Kubernetes API"
   ansible.builtin.assert:
@@ -23,5 +22,5 @@
       - pods_list_result.status == 200
       - pods_list_result.json is defined
       - pods_list_result.json.kind == "PodList"
-    fail_msg: "{{ test_name }} generated Kubernetes token failed to access the API"
-    success_msg: "{{ test_name }} generated Kubernetes token successfully accessed the API"
+    fail_msg: "{{ test_name }} generated Kubernetes token failed to access the Kubernetes API"
+    success_msg: "{{ test_name }} generated Kubernetes token successfully accessed the Kubernetes API"

--- a/tests/integration/targets/setup_auth_token/tasks/main.yml
+++ b/tests/integration/targets/setup_auth_token/tasks/main.yml
@@ -14,7 +14,7 @@
           secret_id: "{{ lookup('ansible.builtin.env', 'VAULT_APPROLE_SECRET_ID') | default(vault_approle_secret_id, true) }}"
         return_content: true
       register: vault_login
-      no_log: true
+      # no_log: true
       when: vault_approle_role_id is defined and vault_approle_secret_id is defined
 
     - name: Save Vault token for use in tests

--- a/tests/integration/targets/setup_auth_token/tasks/main.yml
+++ b/tests/integration/targets/setup_auth_token/tasks/main.yml
@@ -14,7 +14,7 @@
           secret_id: "{{ lookup('ansible.builtin.env', 'VAULT_APPROLE_SECRET_ID') | default(vault_approle_secret_id, true) }}"
         return_content: true
       register: vault_login
-      # no_log: true
+      no_log: true
       when: vault_approle_role_id is defined and vault_approle_secret_id is defined
 
     - name: Save Vault token for use in tests

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/aliases
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/aliases
@@ -1,0 +1,1 @@
+setup_vault_dev_with_kubernetes

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/defaults/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/defaults/main.yml
@@ -1,0 +1,22 @@
+---
+container_runtime: "podman"
+ansible_test_kind_binary: "kind"
+ansible_test_kubectl_binary: "kubectl"
+ansible_test_kind_cluster_name: "vault-ansible-test"
+ansible_test_kind_kubeconfig_path: ""
+ansible_test_vault_url: "http://127.0.0.1:8200"
+ansible_test_vault_root_token: "root"
+ansible_test_kubernetes_mount_path: "kubernetes"
+ansible_test_kubernetes_role_name: "superuser"
+ansible_test_kubernetes_namespace: "kube-system"
+ansible_test_kubernetes_audience: ""
+ansible_test_kubernetes_ttl: "1h"
+ansible_test_kubernetes_reviewer_service_account: "vault-reviewer"
+ansible_test_kubernetes_reviewer_cluster_role_binding: "vault-reviewer-binding"
+ansible_test_kubernetes_bound_service_account_names:
+  - "*"
+ansible_test_kubernetes_bound_service_account_namespaces:
+  - "*"
+ansible_test_kubernetes_token_default_ttl: "1h"
+ansible_test_kubernetes_token_max_ttl: "24h"
+

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/defaults/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 container_runtime: "docker"
 ansible_test_kind_binary: "kind"
+ansible_test_vault_mount_path: "approle-integration-tests"
 ansible_test_kubectl_binary: "kubectl"
 ansible_test_kind_cluster_name: "vault-ansible-test"
 ansible_test_kind_kubeconfig_path: ""
@@ -19,4 +20,7 @@ ansible_test_kubernetes_bound_service_account_namespaces:
   - "*"
 ansible_test_kubernetes_token_default_ttl: "1h"
 ansible_test_kubernetes_token_max_ttl: "24h"
+# kind clusters require tokens scoped to the Kubernetes API server audience.
+# This must match the --api-audiences flag of the kube-apiserver (default for kind).
+ansible_test_kubernetes_token_audiences: "https://kubernetes.default.svc.cluster.local"
 

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/defaults/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-container_runtime: "podman"
+container_runtime: "docker"
 ansible_test_kind_binary: "kind"
 ansible_test_kubectl_binary: "kubectl"
 ansible_test_kind_cluster_name: "vault-ansible-test"

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/handlers/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Clean resources
+  ansible.builtin.include_tasks: cleanup.yml
+

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/cleanup.yml
@@ -17,3 +17,23 @@
     path: "{{ ansible_test_tmp_dir.path }}"
   ignore_errors: true
 
+- name: Force-revoke all Kubernetes secrets engine leases (prevents unmount failure if cluster is gone)
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/sys/leases/revoke-force/{{ ansible_test_kubernetes_mount_path }}"
+    method: PUT
+    headers:
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
+    status_code: [200, 204, 400, 404]
+    use_proxy: false
+  failed_when: false
+
+- name: Unmount Kubernetes secrets engine from Vault
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/sys/mounts/{{ ansible_test_kubernetes_mount_path }}"
+    method: DELETE
+    headers:
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
+    status_code: [200, 204, 400, 404]
+    use_proxy: false
+  failed_when: false
+

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/cleanup.yml
@@ -1,0 +1,19 @@
+---
+- name: Delete kind cluster
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kind_binary }}"
+      - delete
+      - cluster
+      - --name
+      - "{{ ansible_test_kind_cluster_name }}"
+  register: _delete_kind_cluster
+  failed_when: false
+  changed_when: _delete_kind_cluster.rc == 0
+
+- name: Delete temporary directory created for kind configuration
+  ansible.builtin.file:
+    state: absent
+    path: "{{ ansible_test_tmp_dir.path }}"
+  ignore_errors: true
+

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
@@ -28,6 +28,9 @@
   environment:
     KIND_EXPERIMENTAL_PROVIDER: "{{ container_runtime }}"
   register: create_kind_cluster
+  timeout: 300
+  async: 300
+  poll: 5
 
 - name: Wait for Kubernetes API server to be ready
   ansible.builtin.command:
@@ -180,7 +183,7 @@
     url: "{{ ansible_test_vault_url }}/v1/{{ ansible_test_kubernetes_mount_path }}/roles/{{ ansible_test_kubernetes_role_name }}"
     method: POST
     headers:
-      X-Vault-Token: "{{ vault_root_token }}"
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
       Content-Type: "application/json"
     body_format: json
     body:

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
@@ -1,0 +1,223 @@
+---
+- name: Create temporary file for kind configuration
+  ansible.builtin.tempfile:
+    suffix: .kind
+    state: directory
+  register: ansible_test_tmp_dir
+  notify: 'Clean resources'
+
+- name: Set kubeconfig path fact
+  ansible.builtin.set_fact:
+    ansible_test_kind_effective_kubeconfig_path: >-
+      {{
+        ansible_test_kind_kubeconfig_path
+        if ansible_test_kind_kubeconfig_path | length > 0
+        else ansible_test_tmp_dir.path ~ '/kubeconfig'
+      }}
+
+- name: Create kind cluster
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kind_binary }}"
+      - create
+      - cluster
+      - --name
+      - "{{ ansible_test_kind_cluster_name }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+  environment:
+    KIND_EXPERIMENTAL_PROVIDER: "{{ container_runtime }}"
+  register: create_kind_cluster
+
+- name: Wait for Kubernetes API server to be ready
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - cluster-info
+  register: kubectl_cluster_info
+  retries: 30
+  delay: 5
+  until: kubectl_cluster_info.rc == 0
+  changed_when: false
+
+- name: Ensure reviewer service account exists
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - create
+      - serviceaccount
+      - "{{ ansible_test_kubernetes_reviewer_service_account }}"
+      - --namespace
+      - "{{ ansible_test_kubernetes_namespace }}"
+  register: create_reviewer_service_account
+  failed_when:
+    - create_reviewer_service_account.rc != 0
+    - "'already exists' not in create_reviewer_service_account.stderr"
+  changed_when: create_reviewer_service_account.rc == 0
+
+- name: Ensure reviewer cluster role binding for auth-delegator exists
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - create
+      - clusterrolebinding
+      - "{{ ansible_test_kubernetes_reviewer_cluster_role_binding }}"
+      - --clusterrole=system:auth-delegator
+      - "--serviceaccount={{ ansible_test_kubernetes_namespace }}:{{ ansible_test_kubernetes_reviewer_service_account }}"
+  register: create_reviewer_cluster_role_binding
+  failed_when:
+    - create_reviewer_cluster_role_binding.rc != 0
+    - "'already exists' not in create_reviewer_cluster_role_binding.stderr"
+  changed_when: create_reviewer_cluster_role_binding.rc == 0
+
+- name: Ensure reviewer has permissions to manage roles and service accounts
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - create
+      - clusterrolebinding
+      - "{{ ansible_test_kubernetes_reviewer_cluster_role_binding }}-admin"
+      - --clusterrole=cluster-admin
+      - "--serviceaccount={{ ansible_test_kubernetes_namespace }}:{{ ansible_test_kubernetes_reviewer_service_account }}"
+  register: create_reviewer_admin_binding
+  failed_when:
+    - create_reviewer_admin_binding.rc != 0
+    - "'already exists' not in create_reviewer_admin_binding.stderr"
+  changed_when: create_reviewer_admin_binding.rc == 0
+
+- name: Get Kubernetes API server URL
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - config
+      - view
+      - --minify
+      - -o
+      - jsonpath={.clusters[0].cluster.server}
+  register: kubernetes_host
+  changed_when: false
+
+- name: Get Kubernetes CA certificate
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - config
+      - view
+      - --raw
+      - --minify
+      - -o
+      - jsonpath={.clusters[0].cluster.certificate-authority-data}
+  register: kubernetes_ca_cert_b64
+  changed_when: false
+
+- name: Get reviewer JWT
+  ansible.builtin.command:
+    argv:
+      - "{{ ansible_test_kubectl_binary }}"
+      - --kubeconfig
+      - "{{ ansible_test_kind_effective_kubeconfig_path }}"
+      - create
+      - token
+      - "{{ ansible_test_kubernetes_reviewer_service_account }}"
+      - --namespace
+      - "{{ ansible_test_kubernetes_namespace }}"
+  register: kubernetes_reviewer_jwt
+  changed_when: false
+
+- name: Enable Kubernetes secrets engine
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/sys/mounts/{{ ansible_test_kubernetes_mount_path }}"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      type: "kubernetes"
+      description: "Kubernetes secrets engine for integration tests"
+    status_code: [200, 204, 400]
+    use_proxy: false
+  register: enable_kubernetes_engine
+  retries: 10
+  delay: 3
+  until: enable_kubernetes_engine.status in [200, 204, 400]
+  no_log: true
+
+- name: Configure Kubernetes secrets engine
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/{{ ansible_test_kubernetes_mount_path }}/config"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      kubernetes_host: "{{ kubernetes_host.stdout }}"
+      kubernetes_ca_cert: "{{ kubernetes_ca_cert_b64.stdout | b64decode }}"
+      service_account_jwt: "{{ kubernetes_reviewer_jwt.stdout }}"
+    status_code: [200, 204]
+    use_proxy: false
+  register: configure_kubernetes_engine
+  retries: 10
+  delay: 3
+  until: configure_kubernetes_engine.status in [200, 204]
+  no_log: true
+
+- name: Configure Kubernetes role
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/{{ ansible_test_kubernetes_mount_path }}/roles/{{ ansible_test_kubernetes_role_name }}"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ vault_root_token }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      allowed_kubernetes_namespaces: "{{ ansible_test_kubernetes_bound_service_account_namespaces | join(',') }}"
+      kubernetes_role_type: "ClusterRole"
+      generated_role_rules: |
+        rules:
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list"]
+      token_default_ttl: "{{ ansible_test_kubernetes_token_default_ttl }}"
+      token_max_ttl: "{{ ansible_test_kubernetes_token_max_ttl }}"
+      name_template: "{{ ansible_test_kubernetes_role_name }}"
+    status_code: [200, 204]
+    use_proxy: false
+  register: configure_kubernetes_role
+  retries: 10
+  delay: 3
+  until: configure_kubernetes_role.status in [200, 204]
+  # no_log: true
+
+- name: Create ACL policy for Kubernetes token integration fixture
+  hashicorp.vault.acl_policy:
+    url: "{{ vault_url }}"
+    namespace: "{{ vault_namespace }}"
+    auth_method: token
+    token: "{{ vault_root_token }}"
+    name: "kubernetes-token-integration-{{ vault_resource_suffix }}"
+    policy: |
+      path "{{ ansible_test_kubernetes_mount_path }}/creds/{{ ansible_test_kubernetes_role_name }}" {
+        capabilities = ["create", "update", "read", "delete"]
+      }
+  when:
+    - vault_root_token is defined
+  no_log: true
+
+- name: Enable kubernetes fixture for downstream targets
+  ansible.builtin.set_fact:
+    ansible_test_kubernetes_fixture_enabled: true
+

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
@@ -200,7 +200,7 @@
   retries: 10
   delay: 3
   until: configure_kubernetes_role.status in [200, 204]
-  # no_log: true
+  no_log: true
 
 - name: Create ACL policy for Kubernetes token integration fixture
   hashicorp.vault.acl_policy:

--- a/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
+++ b/tests/integration/targets/setup_vault_dev_with_kubernetes/tasks/main.yml
@@ -1,4 +1,24 @@
 ---
+- name: Force-revoke all Kubernetes secrets engine leases (prevents unmount failure if cluster is gone)
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/sys/leases/revoke-force/{{ ansible_test_kubernetes_mount_path }}"
+    method: PUT
+    headers:
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
+    status_code: [200, 204, 400, 404]
+    use_proxy: false
+  failed_when: false
+
+- name: Unmount Kubernetes secrets engine if already configured (ensures clean state)
+  ansible.builtin.uri:
+    url: "{{ ansible_test_vault_url }}/v1/sys/mounts/{{ ansible_test_kubernetes_mount_path }}"
+    method: DELETE
+    headers:
+      X-Vault-Token: "{{ ansible_test_vault_root_token }}"
+    status_code: [200, 204, 400, 404]
+    use_proxy: false
+  failed_when: false
+
 - name: Create temporary file for kind configuration
   ansible.builtin.tempfile:
     suffix: .kind
@@ -196,6 +216,7 @@
           verbs: ["get", "list"]
       token_default_ttl: "{{ ansible_test_kubernetes_token_default_ttl }}"
       token_max_ttl: "{{ ansible_test_kubernetes_token_max_ttl }}"
+      token_default_audiences: "{{ ansible_test_kubernetes_token_audiences }}"
       name_template: "{{ ansible_test_kubernetes_role_name }}"
     status_code: [200, 204]
     use_proxy: false
@@ -216,6 +237,24 @@
       path "{{ ansible_test_kubernetes_mount_path }}/creds/{{ ansible_test_kubernetes_role_name }}" {
         capabilities = ["create", "update", "read", "delete"]
       }
+  when:
+    - vault_root_token is defined
+  no_log: true
+
+- name: Attach Kubernetes token policy to AppRole role
+  ansible.builtin.uri:
+    url: "{{ vault_url }}/v1/auth/{{ ansible_test_vault_mount_path }}/role/ansible-test"
+    method: POST
+    headers:
+      X-Vault-Token: "{{ vault_root_token }}"
+      X-Vault-Namespace: "{{ vault_namespace }}"
+      Content-Type: "application/json"
+    body_format: json
+    body:
+      token_policies:
+        - "kubernetes-token-integration-{{ vault_resource_suffix }}"
+    status_code: [200, 204]
+    use_proxy: false
   when:
     - vault_root_token is defined
   no_log: true

--- a/tests/unit/plugins/module_utils/test_vault_kubernetes.py
+++ b/tests/unit/plugins/module_utils/test_vault_kubernetes.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_client import (
+    VaultClient,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+    VaultApiError,
+)
+from ansible_collections.hashicorp.vault.plugins.module_utils.vault_kubernetes import (
+    VaultKubernetes,
+)
+
+TEST_ROLE_NAME = "superuser"
+
+
+@pytest.fixture
+def vault_config():
+    """Vault configuration for testing."""
+    return {
+        "addr": "http://mock-vault:8200",
+        "token": "mock-token",
+        "namespace": "root",
+        "custom_mount_path": "my-ocp-cluster",
+    }
+
+
+@pytest.fixture
+def authenticated_client(vault_config):
+    """Authenticated Vault client for testing."""
+    client = VaultClient(
+        vault_address=vault_config["addr"],
+        vault_namespace=vault_config["namespace"],
+    )
+    client.set_token(vault_config["token"])
+    client._make_request = MagicMock()
+    return client
+
+
+@pytest.fixture
+def mock_generate_token_response():
+    """Mock response from Vault for Kubernetes token generation."""
+    return {
+        "request_id": "5ad6de83-134c-4f51-a003-6c2e8b6f0633",
+        "lease_id": "kubernetes/creds/superuser/abc123",
+        "renewable": False,
+        "lease_duration": 3600,
+        "data": {
+            "service_account_name": "vault-secrets-superuser",
+            "service_account_namespace": "kube-system",
+            "service_account_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9...",
+        },
+    }
+
+
+class TestVaultKubernetes:
+    def test_generate_token_success(self, authenticated_client, mock_generate_token_response):
+        authenticated_client._make_request.return_value = mock_generate_token_response
+
+        kubernetes = VaultKubernetes(client=authenticated_client)
+        token = kubernetes.generate_token(
+            TEST_ROLE_NAME,
+            kubernetes_namespace="kube-system",
+            ttl="1h",
+            audience="openshift",
+        )
+
+        expected_path = f"v1/kubernetes/creds/{TEST_ROLE_NAME}"
+        expected_payload = {
+            "kubernetes_namespace": "kube-system",
+            "ttl": "1h",
+            "audience": "openshift",
+        }
+        authenticated_client._make_request.assert_called_once_with(
+            "POST",
+            expected_path,
+            json=expected_payload,
+        )
+        assert token == {
+            "service_account_name": "vault-secrets-superuser",
+            "service_account_namespace": "kube-system",
+            "service_account_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9...",
+            "lease_id": "kubernetes/creds/superuser/abc123",
+            "lease_duration": 3600,
+            "renewable": False,
+        }
+
+    def test_generate_token_custom_mount_path_success(
+        self, authenticated_client, vault_config, mock_generate_token_response
+    ):
+        authenticated_client._make_request.return_value = mock_generate_token_response
+
+        kubernetes = VaultKubernetes(
+            client=authenticated_client,
+            mount_path=vault_config["custom_mount_path"],
+        )
+        token = kubernetes.generate_token(TEST_ROLE_NAME)
+
+        expected_path = f"v1/{vault_config['custom_mount_path']}/creds/{TEST_ROLE_NAME}"
+        authenticated_client._make_request.assert_called_once_with(
+            "POST",
+            expected_path,
+            json={},
+        )
+        assert token["service_account_name"] == "vault-secrets-superuser"
+
+    def test_generate_token_omits_none_values(self, authenticated_client, mock_generate_token_response):
+        authenticated_client._make_request.return_value = mock_generate_token_response
+
+        kubernetes = VaultKubernetes(client=authenticated_client)
+        kubernetes.generate_token(TEST_ROLE_NAME, ttl="1h")
+
+        expected_path = f"v1/kubernetes/creds/{TEST_ROLE_NAME}"
+        authenticated_client._make_request.assert_called_once_with(
+            "POST",
+            expected_path,
+            json={"ttl": "1h"},
+        )
+
+    def test_generate_token_error(self, authenticated_client):
+        authenticated_client._make_request.side_effect = VaultApiError("Test error")
+
+        kubernetes = VaultKubernetes(authenticated_client)
+        with pytest.raises(VaultApiError):
+            kubernetes.generate_token(TEST_ROLE_NAME)

--- a/tests/unit/plugins/module_utils/test_vault_kubernetes.py
+++ b/tests/unit/plugins/module_utils/test_vault_kubernetes.py
@@ -109,9 +109,15 @@ class TestVaultKubernetes:
         authenticated_client._make_request.assert_called_once_with(
             "POST",
             expected_path,
-            json={},
         )
-        assert token["service_account_name"] == "vault-secrets-superuser"
+        assert token == {
+            "service_account_name": "vault-secrets-superuser",
+            "service_account_namespace": "kube-system",
+            "service_account_token": "eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9...",
+            "lease_id": "kubernetes/creds/superuser/abc123",
+            "lease_duration": 3600,
+            "renewable": False,
+        }
 
     def test_generate_token_omits_none_values(self, authenticated_client, mock_generate_token_response):
         authenticated_client._make_request.return_value = mock_generate_token_response
@@ -132,3 +138,18 @@ class TestVaultKubernetes:
         kubernetes = VaultKubernetes(authenticated_client)
         with pytest.raises(VaultApiError):
             kubernetes.generate_token(TEST_ROLE_NAME)
+
+    def test_generate_token_empty_name_raises_error(self, authenticated_client):
+        kubernetes = VaultKubernetes(authenticated_client)
+        with pytest.raises(ValueError, match="Role name cannot be empty"):
+            kubernetes.generate_token("")
+
+    def test_generate_token_none_name_raises_error(self, authenticated_client):
+        kubernetes = VaultKubernetes(authenticated_client)
+        with pytest.raises(ValueError, match="Role name cannot be empty"):
+            kubernetes.generate_token(None)
+
+    def test_generate_token_whitespace_name_raises_error(self, authenticated_client):
+        kubernetes = VaultKubernetes(authenticated_client)
+        with pytest.raises(ValueError, match="Role name cannot be empty"):
+            kubernetes.generate_token("   ")

--- a/tests/unit/plugins/modules/test_kubernetes_token.py
+++ b/tests/unit/plugins/modules/test_kubernetes_token.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2026 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+MODULE = "ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token"
+
+FAKE_TOKEN_DATA = {
+    "service_account_token": "supersecrettoken",
+    "service_account_name": "vault-secrets-superuser",
+    "service_account_namespace": "kube-system",
+    "lease_id": "kubernetes/creds/superuser/abc123",
+    "lease_duration": 3600,
+    "renewable": False,
+}
+
+
+def _make_module(check_mode=False):
+    """Return a minimal AnsibleModule mock with no_log_values initialised."""
+    module = MagicMock()
+    module.check_mode = check_mode
+    module.no_log_values = set()
+    module.params = {
+        "kubernetes_mount_path": "kubernetes",
+        "name": "superuser",
+        "kubernetes_namespace": "kube-system",
+        "ttl": "1h",
+        "audience": None,
+    }
+    return module
+
+
+# ---------------------------------------------------------------------------
+# no_log_values scrubbing
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}.VaultKubernetes")
+@patch(f"{MODULE}.get_authenticated_client")
+@patch(f"{MODULE}.AnsibleModule")
+def test_service_account_token_available_in_registered_result(mock_ansible_module, mock_auth, mock_k8s_cls):
+    """The bearer token must be present in the exit_json result so callers can use it.
+
+    Protection against accidental exposure is the responsibility of the task author
+    via no_log: true at the task level — the module does not scrub no_log_values
+    because doing so would make the token unavailable to subsequent tasks.
+    """
+    module = _make_module()
+    mock_ansible_module.return_value = module
+
+    mock_k8s = MagicMock()
+    mock_k8s.generate_token.return_value = FAKE_TOKEN_DATA
+    mock_k8s_cls.return_value = mock_k8s
+
+    from ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token import main
+
+    main()
+
+    _, kwargs = module.exit_json.call_args
+    assert kwargs["kubernetes_token"]["service_account_token"] == "supersecrettoken"
+
+
+@patch(f"{MODULE}.VaultKubernetes")
+@patch(f"{MODULE}.get_authenticated_client")
+@patch(f"{MODULE}.AnsibleModule")
+def test_missing_service_account_token_does_not_raise(mock_ansible_module, mock_auth, mock_k8s_cls):
+    """If service_account_token is absent from the Vault response no exception should be raised."""
+    module = _make_module()
+    mock_ansible_module.return_value = module
+
+    data_without_token = {k: v for k, v in FAKE_TOKEN_DATA.items() if k != "service_account_token"}
+    mock_k8s = MagicMock()
+    mock_k8s.generate_token.return_value = data_without_token
+    mock_k8s_cls.return_value = mock_k8s
+
+    from ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token import main
+
+    main()
+
+    assert len(module.no_log_values) == 0
+    module.exit_json.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Normal execution
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}.VaultKubernetes")
+@patch(f"{MODULE}.get_authenticated_client")
+@patch(f"{MODULE}.AnsibleModule")
+def test_exit_json_called_with_changed_and_full_token_dict(mock_ansible_module, mock_auth, mock_k8s_cls):
+    """exit_json must be called with changed=True and the complete token dict returned by Vault."""
+    module = _make_module()
+    mock_ansible_module.return_value = module
+
+    mock_k8s = MagicMock()
+    mock_k8s.generate_token.return_value = FAKE_TOKEN_DATA
+    mock_k8s_cls.return_value = mock_k8s
+
+    from ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token import main
+
+    main()
+
+    module.exit_json.assert_called_once_with(changed=True, kubernetes_token=FAKE_TOKEN_DATA)
+
+
+# ---------------------------------------------------------------------------
+# check_mode
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}.AnsibleModule")
+def test_check_mode_exits_without_contacting_vault(mock_ansible_module):
+    """In check mode the module must exit immediately with an empty token dict and never call Vault.
+
+    exit_json is configured to raise SystemExit to replicate AnsibleModule's real behaviour —
+    without this the mock doesn't halt execution and main() falls through to get_authenticated_client.
+    """
+    module = _make_module(check_mode=True)
+    module.exit_json.side_effect = SystemExit(0)
+    mock_ansible_module.return_value = module
+
+    from ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token import main
+
+    with pytest.raises(SystemExit):
+        main()
+
+    module.exit_json.assert_called_once_with(changed=True, kubernetes_token={})
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+@patch(f"{MODULE}.VaultKubernetes")
+@patch(f"{MODULE}.get_authenticated_client")
+@patch(f"{MODULE}.AnsibleModule")
+def test_vault_permission_error_surfaces_as_fail_json(mock_ansible_module, mock_auth, mock_k8s_cls):
+    """A VaultPermissionError from generate_token must call fail_json with a 'Permission denied' message."""
+    from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+        VaultPermissionError,
+    )
+
+    module = _make_module()
+    mock_ansible_module.return_value = module
+
+    mock_k8s = MagicMock()
+    mock_k8s.generate_token.side_effect = VaultPermissionError("forbidden")
+    mock_k8s_cls.return_value = mock_k8s
+
+    from ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token import main
+
+    main()
+
+    _, kwargs = module.fail_json.call_args
+    assert "Permission denied" in kwargs.get("msg", "")
+
+
+@patch(f"{MODULE}.VaultKubernetes")
+@patch(f"{MODULE}.get_authenticated_client")
+@patch(f"{MODULE}.AnsibleModule")
+def test_vault_api_error_surfaces_as_fail_json(mock_ansible_module, mock_auth, mock_k8s_cls):
+    """A VaultApiError from generate_token must call fail_json with a 'Vault API error' message."""
+    from ansible_collections.hashicorp.vault.plugins.module_utils.vault_exceptions import (
+        VaultApiError,
+    )
+
+    module = _make_module()
+    mock_ansible_module.return_value = module
+
+    mock_k8s = MagicMock()
+    mock_k8s.generate_token.side_effect = VaultApiError("bad request")
+    mock_k8s_cls.return_value = mock_k8s
+
+    from ansible_collections.hashicorp.vault.plugins.modules.kubernetes_token import main
+
+    main()
+
+    _, kwargs = module.fail_json.call_args
+    assert "Vault API error" in kwargs.get("msg", "")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The goal of this PR is adding a method for fetching a Kubernetes token using the [Vault Kubernetes secrets engine](https://developer.hashicorp.com/vault/docs/secrets/kubernetes). The return value should be a short-lived bearer token for use with a Kubernetes or OpenShift cluster.
Fixes #127 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
hashicorp.vault.kubernetes_token

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To execute the integration tests, a kubernetes cluster is required. This PR uses docker to run a KIND cluster on the local machine for testing. All unit and integration tests pass in my testing but this adds significant testing complexity.
